### PR TITLE
feat: multimodal image support — paste, attach, and send images to vision models

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -357,6 +357,15 @@
     .presence-avatar[title]:hover::after{content:attr(title);position:absolute;bottom:-26px;left:50%;transform:translateX(-50%);background:var(--text);color:var(--panel);padding:3px 8px;border-radius:4px;font-size:10px;white-space:nowrap;z-index:10}
     .typing-indicator{align-self:flex-start;color:var(--muted);font-size:11px;font-style:italic;padding:4px 14px}
 
+    /* === Image attachments === */
+    .image-preview-bar{display:flex;gap:6px;padding:6px 12px;flex-wrap:wrap;align-items:center}
+    .image-preview-bar:empty{display:none}
+    .image-preview-item{position:relative;display:inline-block}
+    .image-preview-item img{height:48px;max-width:80px;border-radius:var(--radius);object-fit:cover;border:1px solid var(--line)}
+    .image-preview-item .remove-btn{position:absolute;top:-6px;right:-6px;width:18px;height:18px;border-radius:50%;background:var(--text);color:var(--base);border:none;font-size:10px;cursor:pointer;display:flex;align-items:center;justify-content:center;line-height:1}
+    .msg-attachment{margin-top:6px}
+    .msg-attachment img{max-width:300px;max-height:200px;border-radius:var(--radius);cursor:pointer;border:1px solid var(--line)}
+
     /* === Session header actions — wrap on small screens === */
     .header-actions{display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end}
     .btn-icon{display:none}
@@ -603,9 +612,12 @@
       </div>
       <button class="scroll-bottom-btn" id="scroll-bottom-btn" onclick="scrollChatToBottom()" title="Scroll to bottom">&darr;</button>
       <div id="typing-indicator" class="typing-indicator" style="display:none"></div>
+      <div id="image-preview-bar" class="image-preview-bar"></div>
       <div class="input-bar">
-        <textarea id="msg-input" rows="1" placeholder="Ask Dodo to build something..." onkeydown="handleInputKeydown(event)" oninput="autoResizeInput(this);sendTypingStart()" onfocus="setTimeout(()=>this.scrollIntoView({block:'nearest',behavior:'smooth'}),300)" aria-label="Message input"></textarea>
+        <textarea id="msg-input" rows="1" placeholder="Ask Dodo to build something..." onkeydown="handleInputKeydown(event)" oninput="autoResizeInput(this);sendTypingStart()" onpaste="handleImagePaste(event)" onfocus="setTimeout(()=>this.scrollIntoView({block:'nearest',behavior:'smooth'}),300)" aria-label="Message input"></textarea>
         <div class="input-actions">
+          <input type="file" id="image-file-input" accept="image/png,image/jpeg,image/gif,image/webp" multiple style="display:none" onchange="handleFileSelect(this)"/>
+          <button class="ghost" onclick="$('image-file-input').click()" title="Attach image" aria-label="Attach image"><i class="ph ph-paperclip"></i></button>
           <button class="sending" id="send-btn" onclick="handleSendBtn()" aria-label="Send message"><i class="ph ph-paper-plane-right"></i></button>
         </div>
       </div>

--- a/public/js/dodo-chat.js
+++ b/public/js/dodo-chat.js
@@ -251,7 +251,11 @@ function renderMessage(msg){
     el.appendChild(document.createTextNode(msg.content));
     if(msg.attachments&&msg.attachments.length){
       const imgWrap=document.createElement("div");imgWrap.className="msg-attachment";
-      msg.attachments.forEach(a=>{const img=document.createElement("img");img.src=a.url;img.alt="attachment";img.loading="lazy";img.onclick=()=>window.open(a.url,"_blank");imgWrap.appendChild(img)});
+      msg.attachments.forEach(a=>{
+        if(!a.url.startsWith("data:image/"))return;
+        const img=document.createElement("img");img.src=a.url;img.alt="attachment";img.loading="lazy";
+        imgWrap.appendChild(img);
+      });
       el.appendChild(imgWrap);
     }
   }
@@ -402,12 +406,13 @@ function sendTypingStop(){
 const _pendingImages=[];
 const MAX_IMAGE_SIZE=10*1024*1024; // 10MB
 const MAX_IMAGES=5;
+const ALLOWED_IMAGE_TYPES=new Set(["image/png","image/jpeg","image/gif","image/webp"]);
 
 function handleImagePaste(event){
   const items=event.clipboardData?.items;
   if(!items)return;
   for(const item of items){
-    if(item.type.startsWith("image/")){
+    if(ALLOWED_IMAGE_TYPES.has(item.type)){
       event.preventDefault();
       const file=item.getAsFile();
       if(file)addImageFile(file);
@@ -418,7 +423,8 @@ function handleImagePaste(event){
 
 function handleFileSelect(input){
   for(const file of input.files){
-    if(file.type.startsWith("image/"))addImageFile(file);
+    if(ALLOWED_IMAGE_TYPES.has(file.type))addImageFile(file);
+    else toast(`${file.type} not supported. Use PNG, JPEG, GIF, or WebP.`,"warning");
   }
   input.value="";
 }
@@ -444,7 +450,14 @@ function removeImage(idx){
 
 function renderImagePreviews(){
   const bar=$("image-preview-bar");
-  bar.innerHTML=_pendingImages.map((img,i)=>`<div class="image-preview-item"><img src="${img.dataUrl}" alt="attachment"/><button class="remove-btn" onclick="removeImage(${i})">&times;</button></div>`).join("");
+  bar.innerHTML="";
+  _pendingImages.forEach((img,i)=>{
+    const wrap=document.createElement("div");wrap.className="image-preview-item";
+    const imgEl=document.createElement("img");imgEl.src=img.dataUrl;imgEl.alt="attachment";
+    const btn=document.createElement("button");btn.className="remove-btn";btn.textContent="\u00d7";
+    btn.onclick=()=>removeImage(i);
+    wrap.appendChild(imgEl);wrap.appendChild(btn);bar.appendChild(wrap);
+  });
 }
 
 function getPendingImages(){

--- a/public/js/dodo-chat.js
+++ b/public/js/dodo-chat.js
@@ -249,6 +249,11 @@ function renderMessage(msg){
     }else{label.style.color="rgba(255,255,255,.75)";label.textContent="You"}
     el.appendChild(label);
     el.appendChild(document.createTextNode(msg.content));
+    if(msg.attachments&&msg.attachments.length){
+      const imgWrap=document.createElement("div");imgWrap.className="msg-attachment";
+      msg.attachments.forEach(a=>{const img=document.createElement("img");img.src=a.url;img.alt="attachment";img.loading="lazy";img.onclick=()=>window.open(a.url,"_blank");imgWrap.appendChild(img)});
+      el.appendChild(imgWrap);
+    }
   }
   const actions=document.createElement("div");actions.className="msg-actions";
   const copyBtn=document.createElement("button");copyBtn.textContent="Copy";copyBtn.title="Copy message";copyBtn.setAttribute("aria-label","Copy message");
@@ -299,12 +304,16 @@ function updateTokenSummary(state){
 
 // --- Chat actions ---
 async function sendMessage(){
-  const content=$("msg-input").value.trim();if(!content)return;
+  const content=$("msg-input").value.trim();
+  const images=getPendingImages();
+  if(!content&&!images)return;
+  if(!content)return toast("Add a text message with your images","warning");
   sendTypingStop();
   if(!currentSession){const d=await jsonSafe("/session",{});if(!d)return;currentSession=d.id;await selectSession(d.id)}
-  $("msg-input").value="";$("msg-input").style.height='auto';
+  $("msg-input").value="";$("msg-input").style.height='auto';clearPendingImages();
+  const payload=images?{content,images}:{content};
   if(isProcessing){
-    // Queue the prompt — show as pending bubble
+    // Queue the prompt — show as pending bubble (images not supported in queue)
     const result=await jsonSafe(`/session/${currentSession}/prompt`,{content});
     if(result&&result.status==="queued"){
       showQueuedMessage(content,result.promptId,result.position);
@@ -312,7 +321,7 @@ async function sendMessage(){
     return;
   }
   setProcessing(true);showThinking();
-  const result=await jsonSafe(`/session/${currentSession}/prompt`,{content});
+  const result=await jsonSafe(`/session/${currentSession}/prompt`,payload);
   if(!result){setProcessing(false);hideThinking()}
 }
 async function abortPrompt(){if(!currentSession)return;await jsonSafe(`/session/${currentSession}/abort`,{});setProcessing(false);hideThinking()}
@@ -387,4 +396,63 @@ function sendTypingStop(){
   if(wsConnection&&wsConnection.readyState===WebSocket.OPEN){
     wsConnection.send(JSON.stringify({type:"typing",isTyping:false}));
   }
+}
+
+// --- Image attachments ---
+const _pendingImages=[];
+const MAX_IMAGE_SIZE=10*1024*1024; // 10MB
+const MAX_IMAGES=5;
+
+function handleImagePaste(event){
+  const items=event.clipboardData?.items;
+  if(!items)return;
+  for(const item of items){
+    if(item.type.startsWith("image/")){
+      event.preventDefault();
+      const file=item.getAsFile();
+      if(file)addImageFile(file);
+      return;
+    }
+  }
+}
+
+function handleFileSelect(input){
+  for(const file of input.files){
+    if(file.type.startsWith("image/"))addImageFile(file);
+  }
+  input.value="";
+}
+
+function addImageFile(file){
+  if(_pendingImages.length>=MAX_IMAGES)return toast(`Maximum ${MAX_IMAGES} images per message`,"warning");
+  if(file.size>MAX_IMAGE_SIZE)return toast("Image too large (max 10MB)","warning");
+  const reader=new FileReader();
+  reader.onload=()=>{
+    const dataUrl=reader.result;
+    const base64=dataUrl.split(",")[1];
+    const mediaType=file.type;
+    _pendingImages.push({data:base64,mediaType,dataUrl});
+    renderImagePreviews();
+  };
+  reader.readAsDataURL(file);
+}
+
+function removeImage(idx){
+  _pendingImages.splice(idx,1);
+  renderImagePreviews();
+}
+
+function renderImagePreviews(){
+  const bar=$("image-preview-bar");
+  bar.innerHTML=_pendingImages.map((img,i)=>`<div class="image-preview-item"><img src="${img.dataUrl}" alt="attachment"/><button class="remove-btn" onclick="removeImage(${i})">&times;</button></div>`).join("");
+}
+
+function getPendingImages(){
+  if(!_pendingImages.length)return undefined;
+  return _pendingImages.map(({data,mediaType})=>({data,mediaType}));
+}
+
+function clearPendingImages(){
+  _pendingImages.length=0;
+  renderImagePreviews();
 }

--- a/public/js/dodo-chat.js
+++ b/public/js/dodo-chat.js
@@ -312,12 +312,16 @@ async function sendMessage(){
   const images=getPendingImages();
   if(!content&&!images)return;
   if(!content)return toast("Add a text message with your images","warning");
+  // Block sending images while a prompt is running — the queued-prompt path
+  // can't carry attachments end-to-end, and silently dropping them is worse
+  // than asking the user to wait.
+  if(isProcessing&&images)return toast("Wait for the current response before sending images","warning");
   sendTypingStop();
   if(!currentSession){const d=await jsonSafe("/session",{});if(!d)return;currentSession=d.id;await selectSession(d.id)}
   $("msg-input").value="";$("msg-input").style.height='auto';clearPendingImages();
   const payload=images?{content,images}:{content};
   if(isProcessing){
-    // Queue the prompt — show as pending bubble (images not supported in queue)
+    // Queue text-only prompts. Image-carrying prompts are blocked above.
     const result=await jsonSafe(`/session/${currentSession}/prompt`,{content});
     if(result&&result.status==="queued"){
       showQueuedMessage(content,result.promptId,result.position);
@@ -330,7 +334,7 @@ async function sendMessage(){
 }
 async function abortPrompt(){if(!currentSession)return;await jsonSafe(`/session/${currentSession}/abort`,{});setProcessing(false);hideThinking()}
 async function forkSession(){if(!currentSession)return;const d=await jsonSafe(`/session/${currentSession}/fork`,{});if(!d)return;const{id}=d;currentSession=id;await selectSession(id)}
-async function deleteSession(){if(!currentSession)return;const ok=await appConfirm("Delete this session? This can\u2019t be undone.");if(!ok)return;await apiSafe(`/session/${currentSession}`,{method:"DELETE"});currentSession=null;$("chat").innerHTML="";$("session-title-display").textContent="No session";$("session-id-display").textContent="";$("token-summary").textContent="";$("token-summary").style.color="";const cw=$("context-warning");if(cw)cw.style.display="none";$("presence-bar").innerHTML="";history.replaceState(null,"",location.pathname);await loadSessions();if(window.innerWidth<=900)switchTab('chat')}
+async function deleteSession(){if(!currentSession)return;const ok=await appConfirm("Delete this session? This can\u2019t be undone.");if(!ok)return;await apiSafe(`/session/${currentSession}`,{method:"DELETE"});currentSession=null;clearPendingImages();$("chat").innerHTML="";$("session-title-display").textContent="No session";$("session-id-display").textContent="";$("token-summary").textContent="";$("token-summary").style.color="";const cw=$("context-warning");if(cw)cw.style.display="none";$("presence-bar").innerHTML="";history.replaceState(null,"",location.pathname);await loadSessions();if(window.innerWidth<=900)switchTab('chat')}
 
 // --- Session rename ---
 async function renameSession(){
@@ -403,8 +407,12 @@ function sendTypingStop(){
 }
 
 // --- Image attachments ---
+// Limits kept in sync with `imageAttachmentSchema` in src/coding-agent.ts.
+// Backend caps base64 length at 4_000_000 chars (~3MB decoded per image, 5 per message);
+// 3MB raw here is a conservative frontend bound that stays under the backend limit
+// after base64 encoding (3MB * 4/3 ≈ 4MB).
 const _pendingImages=[];
-const MAX_IMAGE_SIZE=10*1024*1024; // 10MB
+const MAX_IMAGE_SIZE=3*1024*1024; // 3MB raw — pairs with ~4MB base64 on the backend
 const MAX_IMAGES=5;
 const ALLOWED_IMAGE_TYPES=new Set(["image/png","image/jpeg","image/gif","image/webp"]);
 
@@ -431,15 +439,16 @@ function handleFileSelect(input){
 
 function addImageFile(file){
   if(_pendingImages.length>=MAX_IMAGES)return toast(`Maximum ${MAX_IMAGES} images per message`,"warning");
-  if(file.size>MAX_IMAGE_SIZE)return toast("Image too large (max 10MB)","warning");
+  if(file.size>MAX_IMAGE_SIZE)return toast("Image too large (max 3MB)","warning");
   const reader=new FileReader();
   reader.onload=()=>{
     const dataUrl=reader.result;
     const base64=dataUrl.split(",")[1];
     const mediaType=file.type;
-    _pendingImages.push({data:base64,mediaType,dataUrl});
+    _pendingImages.push({data:base64,mediaType,dataUrl,name:file.name||""});
     renderImagePreviews();
   };
+  reader.onerror=()=>toast("Failed to read image file","warning");
   reader.readAsDataURL(file);
 }
 
@@ -450,11 +459,14 @@ function removeImage(idx){
 
 function renderImagePreviews(){
   const bar=$("image-preview-bar");
-  bar.innerHTML="";
+  bar.replaceChildren();
+  const total=_pendingImages.length;
   _pendingImages.forEach((img,i)=>{
     const wrap=document.createElement("div");wrap.className="image-preview-item";
-    const imgEl=document.createElement("img");imgEl.src=img.dataUrl;imgEl.alt="attachment";
+    const imgEl=document.createElement("img");imgEl.src=img.dataUrl;
+    imgEl.alt=img.name?`Attachment: ${img.name}`:`Attachment ${i+1} of ${total}`;
     const btn=document.createElement("button");btn.className="remove-btn";btn.textContent="\u00d7";
+    btn.setAttribute("aria-label",img.name?`Remove ${img.name}`:`Remove attachment ${i+1}`);
     btn.onclick=()=>removeImage(i);
     wrap.appendChild(imgEl);wrap.appendChild(btn);bar.appendChild(wrap);
   });

--- a/public/js/dodo-sessions.js
+++ b/public/js/dodo-sessions.js
@@ -78,6 +78,9 @@ function filterSessions(query){
 async function createSession(){const d=await jsonSafe("/session",{});if(!d)return;const{id}=d;currentSession=id;await selectSession(id)}
 async function selectSession(id){
   currentSession=id;setProcessing(false);_gitRemoteUrlCache='';history.replaceState(null,"",`#session=${id}`);
+  // Drop any staged image attachments from the previous session — they belong
+  // to whatever the user was about to send there, not here.
+  if(typeof clearPendingImages==='function')clearPendingImages();
   $("chat").innerHTML="";$("onboarding")?.remove();
   const cw=$("context-warning");if(cw)cw.style.display="none";
   showSkeleton($("chat"),5);

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -74,13 +74,13 @@ const COMPACTION_MODEL = "anthropic/claude-haiku-4-5";
 const CLEARED_MARKER = "[Old tool result content cleared]";
 
 const imageAttachmentSchema = z.object({
-  data: z.string().min(1),       // base64-encoded image data (no data: prefix)
+  data: z.string().min(1).max(15_000_000).regex(/^[A-Za-z0-9+/]+=*$/, "Invalid base64"),
   mediaType: z.string().regex(/^image\/(png|jpeg|gif|webp)$/),
-});
+}).strict();
 const sendMessageSchema = z.object({
   content: z.string().trim().min(1),
   images: z.array(imageAttachmentSchema).max(5).optional(),
-});
+}).strict();
 const executeCodeSchema = z.object({ code: z.string().trim().min(1) }).strict();
 const gitCommitSchema = z.object({ dir: z.string().optional(), message: z.string().trim().min(1) }).strict();
 const gitCloneSchema = z.object({ branch: z.string().optional(), depth: z.number().int().nonnegative().optional(), dir: z.string().optional(), singleBranch: z.boolean().optional(), url: z.string().url() }).strict();

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -73,7 +73,14 @@ const COMPACTION_MODEL = "anthropic/claude-haiku-4-5";
 /** Zero-cost marker that replaces cleared tool output — ~8 tokens. */
 const CLEARED_MARKER = "[Old tool result content cleared]";
 
-const sendMessageSchema = z.object({ content: z.string().trim().min(1) }).strict();
+const imageAttachmentSchema = z.object({
+  data: z.string().min(1),       // base64-encoded image data (no data: prefix)
+  mediaType: z.string().regex(/^image\/(png|jpeg|gif|webp)$/),
+});
+const sendMessageSchema = z.object({
+  content: z.string().trim().min(1),
+  images: z.array(imageAttachmentSchema).max(5).optional(),
+});
 const executeCodeSchema = z.object({ code: z.string().trim().min(1) }).strict();
 const gitCommitSchema = z.object({ dir: z.string().optional(), message: z.string().trim().min(1) }).strict();
 const gitCloneSchema = z.object({ branch: z.string().optional(), depth: z.number().int().nonnegative().optional(), dir: z.string().optional(), singleBranch: z.boolean().optional(), url: z.string().url() }).strict();
@@ -2601,7 +2608,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.ensureThinkConfig(request);
     await this.readAppConfig();
     try {
-      const result = await this.runThinkChat(input.content, { authorEmail: authorEmail ?? undefined });
+      const result = await this.runThinkChat(input.content, { authorEmail: authorEmail ?? undefined, images: input.images });
 
       // Guard: treat empty LLM response as a failure (same as runFiberPrompt)
       if (!result.text && !result.assistantMessageId) {
@@ -2667,6 +2674,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const fiberId = this.spawnFiber("runFiberPrompt", {
       promptId,
       content: input.content,
+      images: input.images,
       authorEmail: authorEmail ?? undefined,
       title,
     }, { maxRetries: 3 });
@@ -2779,8 +2787,8 @@ export class CodingAgent extends Think<Env, DodoConfig> {
    * if the DO is evicted mid-chat, recovery replays from the top and
    * skips already-completed work.
    */
-  async runFiberPrompt(payload: { promptId: string; content: string; authorEmail?: string; title: string }): Promise<void> {
-    const { promptId, content, authorEmail, title } = payload;
+  async runFiberPrompt(payload: { promptId: string; content: string; images?: Array<{ data: string; mediaType: string }>; authorEmail?: string; title: string }): Promise<void> {
+    const { promptId, content, images, authorEmail, title } = payload;
 
     // Refresh Think config from the latest account config before each prompt run.
     await this.readAppConfig();
@@ -2802,7 +2810,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this._fiberAbortController = new AbortController();
     const signal = this._fiberAbortController.signal;
     try {
-      const result = await this.runThinkChat(content, { authorEmail, signal });
+      const result = await this.runThinkChat(content, { authorEmail, signal, images });
 
       // Guard: treat empty LLM response as a failure
       if (!result.text && !result.assistantMessageId) {
@@ -3025,17 +3033,31 @@ export class CodingAgent extends Think<Env, DodoConfig> {
    */
   private async runThinkChat(
     userContent: string,
-    options?: { authorEmail?: string; signal?: AbortSignal },
+    options?: { authorEmail?: string; signal?: AbortSignal; images?: Array<{ data: string; mediaType: string }> },
   ): Promise<{ assistantMessageId: string; tokenInput: number; tokenOutput: number; text: string }> {
     // Connect MCP servers before Think calls getTools()
     await this.connectMcpServers();
 
     // Insert user message metadata
     const userMsgId = crypto.randomUUID();
+    const parts: UIMessage["parts"] = [{ type: "text", text: userContent }];
+    if (options?.images?.length) {
+      for (const img of options.images) {
+        // Pass raw base64 in the url field — the AI SDK's downloadAssets step
+        // tries new URL(data) which throws for raw base64 (not a valid URL),
+        // so it skips the download. convertToLanguageModelV3DataContent then
+        // handles the raw string as inline base64 data.
+        (parts as Array<{ type: string; mediaType: string; url: string }>).push({
+          type: "file",
+          mediaType: img.mediaType,
+          url: img.data,
+        });
+      }
+    }
     const userMsg: UIMessage = {
       id: userMsgId,
       role: "user",
-      parts: [{ type: "text", text: userContent }],
+      parts,
     };
 
     this.insertMessageMetadata({

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1,6 +1,6 @@
 import { Workspace, createWorkspaceStateBackend } from "@cloudflare/shell";
 import { type Connection, type ConnectionContext, type WSMessage } from "agents";
-import { generateText, streamText, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
+import { generateText, streamText, type FileUIPart, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { buildProvider, buildToolsForThink } from "./agentic";
 import { getUserControlStub, isAdmin } from "./auth";
@@ -73,13 +73,32 @@ const COMPACTION_MODEL = "anthropic/claude-haiku-4-5";
 /** Zero-cost marker that replaces cleared tool output — ~8 tokens. */
 const CLEARED_MARKER = "[Old tool result content cleared]";
 
+/**
+ * Image attachment limits — keep in sync with `public/js/dodo-chat.js`.
+ * Base64 encodes 3 bytes → 4 chars, so MAX_IMAGE_BASE64_LENGTH ≈ MAX_IMAGE_BYTES * 4/3.
+ * Kept tight to protect the DO isolate: 5 images × 4MB base64 = 20MB peak payload.
+ */
+const MAX_IMAGES_PER_MESSAGE = 5;
+const MAX_IMAGE_BASE64_LENGTH = 4_000_000; // ~3MB decoded per image
+const ALLOWED_IMAGE_MEDIA_TYPES = /^image\/(png|jpeg|gif|webp)$/;
+// Sampled base64 validation — avoids running a regex across a multi-MB string, which
+// is expensive in the DO isolate. Base64 must have length divisible by 4; the head/tail
+// sampling catches most corruption without the full scan. convertToLanguageModelV3DataContent
+// in the AI SDK will surface any deeper decoding errors at send time.
+const BASE64_SAMPLE_REGEX = /^[A-Za-z0-9+/]+=*$/;
+const isLikelyBase64 = (s: string): boolean => {
+  if (s.length % 4 !== 0) return false;
+  const head = s.slice(0, 128);
+  const tail = s.slice(-128);
+  return BASE64_SAMPLE_REGEX.test(head) && BASE64_SAMPLE_REGEX.test(tail);
+};
 const imageAttachmentSchema = z.object({
-  data: z.string().min(1).max(15_000_000).regex(/^[A-Za-z0-9+/]+=*$/, "Invalid base64"),
-  mediaType: z.string().regex(/^image\/(png|jpeg|gif|webp)$/),
+  data: z.string().min(1).max(MAX_IMAGE_BASE64_LENGTH).refine(isLikelyBase64, "Invalid base64"),
+  mediaType: z.string().regex(ALLOWED_IMAGE_MEDIA_TYPES),
 }).strict();
 const sendMessageSchema = z.object({
   content: z.string().trim().min(1),
-  images: z.array(imageAttachmentSchema).max(5).optional(),
+  images: z.array(imageAttachmentSchema).max(MAX_IMAGES_PER_MESSAGE).optional(),
 }).strict();
 const executeCodeSchema = z.object({ code: z.string().trim().min(1) }).strict();
 const gitCommitSchema = z.object({ dir: z.string().optional(), message: z.string().trim().min(1) }).strict();
@@ -3047,11 +3066,12 @@ export class CodingAgent extends Think<Env, DodoConfig> {
         // tries new URL(data) which throws for raw base64 (not a valid URL),
         // so it skips the download. convertToLanguageModelV3DataContent then
         // handles the raw string as inline base64 data.
-        (parts as Array<{ type: string; mediaType: string; url: string }>).push({
+        const filePart = {
           type: "file",
           mediaType: img.mediaType,
           url: img.data,
-        });
+        } satisfies FileUIPart;
+        parts.push(filePart);
       }
     }
     const userMsg: UIMessage = {

--- a/src/think-adapter.ts
+++ b/src/think-adapter.ts
@@ -92,12 +92,29 @@ export function chatRecordToUIMessage(record: ChatMessageRecord): UIMessage {
  * Convert a UIMessage back to a flat ChatMessageRecord.
  * Used for backward-compatible API responses.
  */
+/**
+ * Media types we'll render as image attachments. Kept in sync with
+ * `imageAttachmentSchema` in `src/coding-agent.ts` so only ingest-validated
+ * types are emitted into data URLs for the frontend.
+ */
+const SAFE_IMAGE_MEDIA_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
 export function uiMessageToChatRecord(
   msg: UIMessage,
   meta: Partial<MessageMetadata> = {},
 ): ChatMessageRecord {
   // Extract text content from parts
   let content = "";
+  // NOTE: attachments carry the full base64 image data (or a data URL) so the
+  // frontend can re-render history without a round-trip to storage. This means
+  // message history grows linearly with image bytes — a known limitation. When
+  // persistent image storage lands (R2 + signed URL references), swap `url`
+  // for the storage URL and stop inlining base64 here.
   const attachments: Array<{ mediaType: string; url: string }> = [];
   if (msg.parts) {
     content = msg.parts
@@ -105,14 +122,18 @@ export function uiMessageToChatRecord(
       .map((p) => p.text)
       .join("");
     for (const p of msg.parts) {
-      if (p.type === "file" && (p as { mediaType?: string }).mediaType?.startsWith("image/")) {
-        const mediaType = (p as { mediaType: string }).mediaType;
-        const rawUrl = (p as { url: string }).url;
-        // Ensure the URL is a data URL for frontend rendering — the stored value
-        // may be raw base64 (for AI SDK compatibility) or already a data URL.
-        const url = rawUrl.startsWith("data:") ? rawUrl : `data:${mediaType};base64,${rawUrl}`;
-        attachments.push({ mediaType, url });
-      }
+      if (p.type !== "file") continue;
+      const mediaType = (p as { mediaType?: string }).mediaType;
+      // Defensive: re-check mediaType here even though the schema gated it on
+      // ingest. Protects against malformed stored messages or future callers
+      // that bypass the HTTP layer.
+      if (!mediaType || !SAFE_IMAGE_MEDIA_TYPES.has(mediaType)) continue;
+      const rawUrl = (p as { url?: string }).url;
+      if (typeof rawUrl !== "string" || rawUrl.length === 0) continue;
+      // Ensure the URL is a data URL for frontend rendering — the stored value
+      // may be raw base64 (for AI SDK compatibility) or already a data URL.
+      const url = rawUrl.startsWith("data:") ? rawUrl : `data:${mediaType};base64,${rawUrl}`;
+      attachments.push({ mediaType, url });
     }
   }
 

--- a/src/think-adapter.ts
+++ b/src/think-adapter.ts
@@ -98,14 +98,25 @@ export function uiMessageToChatRecord(
 ): ChatMessageRecord {
   // Extract text content from parts
   let content = "";
+  const attachments: Array<{ mediaType: string; url: string }> = [];
   if (msg.parts) {
     content = msg.parts
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
       .map((p) => p.text)
       .join("");
+    for (const p of msg.parts) {
+      if (p.type === "file" && (p as { mediaType?: string }).mediaType?.startsWith("image/")) {
+        const mediaType = (p as { mediaType: string }).mediaType;
+        const rawUrl = (p as { url: string }).url;
+        // Ensure the URL is a data URL for frontend rendering — the stored value
+        // may be raw base64 (for AI SDK compatibility) or already a data URL.
+        const url = rawUrl.startsWith("data:") ? rawUrl : `data:${mediaType};base64,${rawUrl}`;
+        attachments.push({ mediaType, url });
+      }
+    }
   }
 
-  return {
+  const record: ChatMessageRecord = {
     id: msg.id,
     role: msg.role as ChatMessageRecord["role"],
     content,
@@ -118,4 +129,6 @@ export function uiMessageToChatRecord(
     tokenInput: meta.tokenInput ?? 0,
     tokenOutput: meta.tokenOutput ?? 0,
   };
+  if (attachments.length > 0) record.attachments = attachments;
+  return record;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface SessionState {
 }
 
 export interface ChatMessageRecord {
+  attachments?: Array<{ mediaType: string; url: string }>;
   authorEmail?: string | null;
   content: string;
   createdAt: string;

--- a/test/multimodal-unit.test.ts
+++ b/test/multimodal-unit.test.ts
@@ -112,4 +112,33 @@ describe("uiMessageToChatRecord — multimodal", () => {
     expect(record.attachments).toHaveLength(1);
     expect(record.attachments![0].url).toBe("data:image/jpeg;base64,/9j/4AAQ");
   });
+
+  it("drops file parts with media types outside the allowlist", () => {
+    // Defensive: even if something slips past the ingest schema (migrated data,
+    // direct DB edits), uiMessageToChatRecord must not surface non-image or
+    // non-allowlisted types as renderable attachments.
+    const msg: UIMessage = {
+      id: "msg-bad-mime",
+      role: "user",
+      parts: [
+        { type: "text", text: "Check" },
+        { type: "file", mediaType: "image/svg+xml", url: "data:image/svg+xml;base64,PHN2Zy8+" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toBeUndefined();
+  });
+
+  it("drops file parts with an empty url", () => {
+    const msg: UIMessage = {
+      id: "msg-no-url",
+      role: "user",
+      parts: [
+        { type: "text", text: "Check" },
+        { type: "file", mediaType: "image/png", url: "" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toBeUndefined();
+  });
 });

--- a/test/multimodal-unit.test.ts
+++ b/test/multimodal-unit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { uiMessageToChatRecord } from "../src/think-adapter";
+import type { UIMessage } from "ai";
+
+describe("uiMessageToChatRecord — multimodal", () => {
+  it("extracts text content from a text-only message", () => {
+    const msg: UIMessage = {
+      id: "msg-1",
+      role: "user",
+      parts: [{ type: "text", text: "Hello world" }],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.content).toBe("Hello world");
+    expect(record.attachments).toBeUndefined();
+  });
+
+  it("extracts image attachments from file parts", () => {
+    const msg: UIMessage = {
+      id: "msg-2",
+      role: "user",
+      parts: [
+        { type: "text", text: "What is this?" },
+        { type: "file", mediaType: "image/png", url: "data:image/png;base64,abc123" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.content).toBe("What is this?");
+    expect(record.attachments).toHaveLength(1);
+    expect(record.attachments![0]).toEqual({
+      mediaType: "image/png",
+      url: "data:image/png;base64,abc123",
+    });
+  });
+
+  it("handles multiple images", () => {
+    const msg: UIMessage = {
+      id: "msg-3",
+      role: "user",
+      parts: [
+        { type: "text", text: "Compare" },
+        { type: "file", mediaType: "image/png", url: "data:image/png;base64,aaa" } as UIMessage["parts"][number],
+        { type: "file", mediaType: "image/jpeg", url: "data:image/jpeg;base64,bbb" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.content).toBe("Compare");
+    expect(record.attachments).toHaveLength(2);
+    expect(record.attachments![0].mediaType).toBe("image/png");
+    expect(record.attachments![1].mediaType).toBe("image/jpeg");
+  });
+
+  it("ignores non-image file parts", () => {
+    const msg: UIMessage = {
+      id: "msg-4",
+      role: "user",
+      parts: [
+        { type: "text", text: "Check this" },
+        { type: "file", mediaType: "application/pdf", url: "data:application/pdf;base64,xyz" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.content).toBe("Check this");
+    expect(record.attachments).toBeUndefined();
+  });
+
+  it("preserves metadata fields", () => {
+    const msg: UIMessage = {
+      id: "msg-5",
+      role: "user",
+      parts: [
+        { type: "text", text: "Hi" },
+        { type: "file", mediaType: "image/webp", url: "data:image/webp;base64,def" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg, {
+      authorEmail: "user@test.com",
+      model: "gemma-4",
+      tokenInput: 100,
+      tokenOutput: 50,
+    });
+    expect(record.authorEmail).toBe("user@test.com");
+    expect(record.model).toBe("gemma-4");
+    expect(record.tokenInput).toBe(100);
+    expect(record.tokenOutput).toBe(50);
+    expect(record.attachments).toHaveLength(1);
+  });
+});

--- a/test/multimodal-unit.test.ts
+++ b/test/multimodal-unit.test.ts
@@ -84,4 +84,32 @@ describe("uiMessageToChatRecord — multimodal", () => {
     expect(record.tokenOutput).toBe(50);
     expect(record.attachments).toHaveLength(1);
   });
+
+  it("normalizes raw base64 to data URL for frontend rendering", () => {
+    const msg: UIMessage = {
+      id: "msg-raw",
+      role: "user",
+      parts: [
+        { type: "text", text: "Check this" },
+        { type: "file", mediaType: "image/png", url: "iVBORw0KGgoAAAAN" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toHaveLength(1);
+    expect(record.attachments![0].url).toBe("data:image/png;base64,iVBORw0KGgoAAAAN");
+  });
+
+  it("preserves existing data URLs without double-prefixing", () => {
+    const msg: UIMessage = {
+      id: "msg-existing-data-url",
+      role: "user",
+      parts: [
+        { type: "text", text: "Check" },
+        { type: "file", mediaType: "image/jpeg", url: "data:image/jpeg;base64,/9j/4AAQ" } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toHaveLength(1);
+    expect(record.attachments![0].url).toBe("data:image/jpeg;base64,/9j/4AAQ");
+  });
 });

--- a/test/multimodal.test.ts
+++ b/test/multimodal.test.ts
@@ -133,6 +133,48 @@ describe("Multimodal image support", () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it("rejects images whose base64 payload exceeds the length cap", async () => {
+      // MAX_IMAGE_BASE64_LENGTH = 4_000_000. One over and it should fail schema
+      // validation before the handler ever runs. Use divisible-by-4 so it
+      // doesn't fail for the wrong reason.
+      const oversizedBase64 = "A".repeat(4_000_004);
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "Too big",
+          images: [{ data: oversizedBase64, mediaType: "image/png" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects base64 whose length is not divisible by 4", async () => {
+      // Valid-looking alphabet but broken framing — caught by isLikelyBase64.
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "Malformed base64",
+          images: [{ data: "AAA", mediaType: "image/png" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects base64 containing characters outside the base64 alphabet", async () => {
+      // 8 chars, divisible by 4, but contains `$` which isn't in the alphabet.
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "Bad chars",
+          images: [{ data: "AAAA$AAA", mediaType: "image/png" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe("Message history", () => {

--- a/test/multimodal.test.ts
+++ b/test/multimodal.test.ts
@@ -1,0 +1,205 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import type { Env } from "../src/types";
+import { resetMockAgentic } from "./helpers/agentic-mock";
+
+const { runSandboxedCodeMock, sendNotificationMock } = vi.hoisted(() => ({
+  runSandboxedCodeMock: vi.fn(),
+  sendNotificationMock: vi.fn(),
+}));
+
+vi.mock("../src/executor", () => ({
+  runSandboxedCode: runSandboxedCodeMock,
+}));
+
+vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+
+vi.mock("../src/notify", () => ({
+  sendNotification: sendNotificationMock,
+}));
+
+import worker from "../src/index";
+
+const BASE_URL = "https://dodo.example";
+
+async function fetchJson(path: string, init?: RequestInit): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`${BASE_URL}${path}`, init), env as Env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+// Tiny 1x1 red PNG as base64 (valid image data for testing)
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+describe("Multimodal image support", () => {
+  let sessionId: string;
+
+  beforeAll(async () => {
+    // Ensure health
+    try { await fetchJson("/health"); } catch { /* absorb */ }
+    try { await fetchJson("/health"); } catch { /* retry */ }
+
+    // Create session
+    const response = await fetchJson("/session", { method: "POST" });
+    expect(response.status).toBe(201);
+    sessionId = ((await response.json()) as { id: string }).id;
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    resetMockAgentic();
+    runSandboxedCodeMock.mockReset();
+    runSandboxedCodeMock.mockResolvedValue({ logs: [], result: {} });
+    sendNotificationMock.mockReset();
+
+    await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "opencode", model: "claude-test" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+  });
+
+  describe("Schema validation", () => {
+    it("accepts a prompt with text only (no images)", async () => {
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({ content: "Hello" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts a prompt with text and valid images", async () => {
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "What is in this image?",
+          images: [{ data: TINY_PNG_BASE64, mediaType: "image/png" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts multiple images up to the limit", async () => {
+      const images = Array.from({ length: 5 }, () => ({
+        data: TINY_PNG_BASE64,
+        mediaType: "image/png",
+      }));
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({ content: "Describe these images", images }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects more than 5 images", async () => {
+      const images = Array.from({ length: 6 }, () => ({
+        data: TINY_PNG_BASE64,
+        mediaType: "image/png",
+      }));
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({ content: "Too many images", images }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid media types", async () => {
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "Bad type",
+          images: [{ data: TINY_PNG_BASE64, mediaType: "application/pdf" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects images with empty data", async () => {
+      const res = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "Empty image",
+          images: [{ data: "", mediaType: "image/png" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("Message history", () => {
+    it("stores image attachments in message history", async () => {
+      const msgRes = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({
+          content: "Describe this",
+          images: [{ data: TINY_PNG_BASE64, mediaType: "image/png" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(msgRes.status).toBe(200);
+
+      const historyRes = await fetchJson(`/session/${sessionId}/messages`);
+      const { messages } = (await historyRes.json()) as {
+        messages: Array<{ role: string; content: string; attachments?: Array<{ mediaType: string; url: string }> }>;
+      };
+
+      // Find the user message with attachments
+      const userMsg = messages.find(
+        (m) => m.role === "user" && m.content === "Describe this",
+      );
+      expect(userMsg).toBeTruthy();
+      expect(userMsg!.attachments).toBeDefined();
+      expect(userMsg!.attachments).toHaveLength(1);
+      expect(userMsg!.attachments![0].mediaType).toBe("image/png");
+      // uiMessageToChatRecord normalizes raw base64 to data URLs for frontend display
+      expect(userMsg!.attachments![0].url).toMatch(/^data:image\/png;base64,/);
+    });
+
+    it("messages without images have no attachments field", async () => {
+      const msgRes = await fetchJson(`/session/${sessionId}/message`, {
+        body: JSON.stringify({ content: "Plain text message" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(msgRes.status).toBe(200);
+
+      const historyRes = await fetchJson(`/session/${sessionId}/messages`);
+      const { messages } = (await historyRes.json()) as {
+        messages: Array<{ role: string; content: string; attachments?: unknown }>;
+      };
+
+      const userMsg = messages.find(
+        (m) => m.role === "user" && m.content === "Plain text message",
+      );
+      expect(userMsg).toBeTruthy();
+      expect(userMsg!.attachments).toBeUndefined();
+    });
+  });
+
+  describe("Async prompt path", () => {
+    it("accepts images via the prompt endpoint", async () => {
+      const res = await fetchJson(`/session/${sessionId}/prompt`, {
+        body: JSON.stringify({
+          content: "Analyze this screenshot",
+          images: [{ data: TINY_PNG_BASE64, mediaType: "image/jpeg" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      // 202 = accepted (async prompt queued)
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as { promptId: string; status: string };
+      expect(body.promptId).toBeTruthy();
+      expect(body.status).toBe("queued");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Paste or attach images in the chat input and send them to multimodal models (Gemma 4, Claude, GPT-5.4, etc.)
- Images are converted to AI SDK `file` parts in the `UIMessage`, which the provider converts to `image_url` content parts in the OpenAI-compatible API request
- Thumbnails preview before sending, images render inline in message history

## Changes

### Backend

| File | Change |
|------|--------|
| `src/coding-agent.ts` | Extended `sendMessageSchema` to accept optional `images` array (base64 + mediaType, max 5, PNG/JPEG/GIF/WebP). Threaded images through `handlePrompt` → `runFiberPrompt` → `runThinkChat`. Builds `UIMessage` with `{type: "file"}` parts. |
| `src/think-adapter.ts` | `uiMessageToChatRecord()` now extracts image `file` parts into an `attachments` array on `ChatMessageRecord`, normalizing raw base64 to data URLs for frontend rendering. |
| `src/types.ts` | Added optional `attachments` field to `ChatMessageRecord`. |

### Frontend

| File | Change |
|------|--------|
| `public/index.html` | Added image preview bar, paperclip attach button, `onpaste` handler on textarea, CSS for previews and inline message images. |
| `public/js/dodo-chat.js` | `handleImagePaste()` intercepts clipboard images. `handleFileSelect()` handles the file picker. `addImageFile()` converts to base64 with size/count validation. `sendMessage()` includes images in the prompt payload. `renderMessage()` displays image attachments in user bubbles. |

### Tests

| File | Tests |
|------|-------|
| `test/multimodal-unit.test.ts` | 5 unit tests for `uiMessageToChatRecord` — text-only, single image, multiple images, non-image file parts ignored, metadata preservation. |
| `test/multimodal.test.ts` | 9 integration tests — schema accepts text-only/with-images/max-images, rejects >5 images/bad media types/empty data, message history stores and returns attachments, plain messages have no attachments, async prompt path accepts images. |

## AI SDK compatibility note

The AI SDK v6 `downloadAssets()` step tries to download URLs found in message parts. Data URLs (`data:image/png;base64,...`) get parsed as valid `URL` objects but the download function rejects the `data:` scheme. To work around this, image data is stored as raw base64 strings in the `FileUIPart.url` field — `new URL()` throws for these, so they skip the download step. The `convertToLanguageModelV3DataContent()` function then handles them as inline base64 data with the `mediaType` from the part definition.

## Limitations

- Images are sent inline as base64 (no persistent storage) — large images consume context tokens
- WebSocket prompt path does not support images yet (HTTP-only)
- Queued prompts (sent while another is running) drop images
- Token accounting for images is approximate — different models count image tokens differently