### PR TITLE
feat: Artifacts migration Phase 1 — wire up binding [DRAFT]

### DIFF
--- a/src/artifacts-types.ts
+++ b/src/artifacts-types.ts
@@ -1,0 +1,20 @@
+// TODO(artifacts-beta): replace with @cloudflare/workers-types once Artifacts is GA
+// API shape based on Cloudflare's public Artifacts beta announcement:
+// https://blog.cloudflare.com/artifacts-git-for-agents-beta/
+// If beta docs differ, update these interfaces to match the real binding.
+
+export interface ArtifactsRepo {
+  readonly name: string;
+  readonly remote: string;
+  readonly token: string;
+  fork(name: string, opts?: { readOnly?: boolean }): Promise<ArtifactsRepo>;
+}
+
+export interface Artifacts {
+  create(name: string): Promise<ArtifactsRepo>;
+  get(name: string): Promise<ArtifactsRepo>;
+  import(opts: {
+    source: { url: string; branch?: string };
+    target: { name: string };
+  }): Promise<ArtifactsRepo>;
+}

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1,5 +1,6 @@
 import { Workspace, createWorkspaceStateBackend } from "@cloudflare/shell";
 import { type Connection, type ConnectionContext, type WSMessage } from "agents";
+import type { ArtifactsRepo } from "./artifacts-types";
 import { generateText, streamText, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { buildProvider, buildToolsForThink } from "./agentic";
@@ -270,6 +271,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
   private mcpDepth = 0;
   /** AbortController for the currently running fiber prompt. Signalled by handleAbort(). */
   private _fiberAbortController: AbortController | null = null;
+  private _artifactsRepo: ArtifactsRepo | null = null;
   private readonly presence = new PresenceTracker();
   readonly stateBackend;
   private readonly transports = new Map<string, AgentConnectionTransport>();
@@ -3702,6 +3704,17 @@ export class CodingAgent extends Think<Env, DodoConfig> {
 
   private sessionId(): string {
     return this.readMetadata("session_id") ?? "";
+  }
+
+  async getOrCreateArtifactsRepo(): Promise<ArtifactsRepo> {
+    if (this._artifactsRepo) return this._artifactsRepo;
+    const name = `dodo-${this.sessionId()}`;
+    try {
+      this._artifactsRepo = await this.env.ARTIFACTS.get(name);
+    } catch {
+      this._artifactsRepo = await this.env.ARTIFACTS.create(name);
+    }
+    return this._artifactsRepo;
   }
 
   private readMetadata(key: string): string | null {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -308,6 +308,12 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     return textResult({ sessionId: newId, sourceSessionId: sessionId, forkedAt: new Date().toISOString() });
   });
 
+  server.tool("get_artifacts_remote", "Get or create the per-session Cloudflare Artifacts repo remote.", { sessionId: z.string() }, async ({ sessionId }) => {
+    const agent = await getAgentByName(env.CODING_AGENT as never, sessionId);
+    const repo = await agent.getOrCreateArtifactsRepo();
+    return textResult({ name: repo.name, remote: repo.remote, token: repo.token });
+  });
+
   server.tool("list_known_repos", "List built-in repositories that the orchestrator can clone without relying on prompt text.", {}, async () =>
     textResult({ repos: listKnownRepos() }),
   );

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getAgentByName } from "agents";
 import { z } from "zod";
 import { getSharedIndexStub, getUserControlStub, resolveAdminEmail } from "./auth";
+import type { CodingAgent } from "./coding-agent";
 import { getKnownRepo, listKnownRepos } from "./repos";
 import type { Env } from "./types";
 
@@ -309,7 +310,7 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
   });
 
   server.tool("get_artifacts_remote", "Get or create the per-session Cloudflare Artifacts repo remote.", { sessionId: z.string() }, async ({ sessionId }) => {
-    const agent = await getAgentByName(env.CODING_AGENT as never, sessionId);
+    const agent = (await getAgentByName(env.CODING_AGENT as never, sessionId)) as unknown as CodingAgent;
     const repo = await agent.getOrCreateArtifactsRepo();
     return textResult({ name: repo.name, remote: repo.remote, token: repo.token });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Artifacts } from "./artifacts-types";
 import type { CodingAgent } from "./coding-agent";
 import type { SharedIndex } from "./shared-index";
 import type { UserControl } from "./user-control";
@@ -19,6 +20,7 @@ export interface Env {
   LOADER?: WorkerLoader;
   OPENCODE_BASE_URL: string;
   OUTBOUND?: Fetcher;
+  ARTIFACTS: Artifacts;
   WORKSPACE_BUCKET?: R2Bucket;
 
   // Durable Object bindings

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -4,7 +4,17 @@ import { env } from "cloudflare:workers";
 import type { Env } from "../src/types";
 import { releaseMockSlowPrompt, resetMockAgentic } from "./helpers/agentic-mock";
 
-const { runSandboxedCodeMock, sendNotificationMock } = vi.hoisted(() => ({
+const { mockArtifacts, runSandboxedCodeMock, sendNotificationMock } = vi.hoisted(() => ({
+  mockArtifacts: {
+    create: vi.fn(async (name: string) => ({
+      name,
+      remote: `https://fake-artifacts.example/${name}.git`,
+      token: "fake-token",
+      fork: vi.fn(),
+    })),
+    get: vi.fn(async () => { throw new Error("not found"); }),
+    import: vi.fn(),
+  },
   runSandboxedCodeMock: vi.fn(),
   sendNotificationMock: vi.fn(),
 }));

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -4,6 +4,8 @@ import { env } from "cloudflare:workers";
 import type { Env } from "../src/types";
 import { releaseMockSlowPrompt, resetMockAgentic } from "./helpers/agentic-mock";
 
+// mockArtifacts is wired up for Phase 2 when the Artifacts binding is exercised by real tools.
+// In Phase 1, get_artifacts_remote exists as dormant infrastructure; no test asserts against it yet.
 const { mockArtifacts, runSandboxedCodeMock, sendNotificationMock } = vi.hoisted(() => ({
   mockArtifacts: {
     create: vi.fn(async (name: string) => ({
@@ -18,6 +20,9 @@ const { mockArtifacts, runSandboxedCodeMock, sendNotificationMock } = vi.hoisted
   runSandboxedCodeMock: vi.fn(),
   sendNotificationMock: vi.fn(),
 }));
+
+// Reference mockArtifacts so the linter doesn't flag it as unused until Phase 2 tests land.
+void mockArtifacts;
 
 vi.mock("../src/executor", () => ({
   runSandboxedCode: runSandboxedCodeMock,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,6 +36,13 @@
   "r2_buckets": [
     { "binding": "WORKSPACE_BUCKET", "bucket_name": "dodo-workspaces" }
   ],
+  // TODO(artifacts-beta): confirm final Wrangler config shape once Artifacts beta access is enabled.
+  "artifacts": [
+    {
+      "binding": "ARTIFACTS",
+      "namespace_id": "TODO_SET_AFTER_BETA_ACCESS"
+    }
+  ],
   "browser": {
     "binding": "BROWSER"
   },


### PR DESCRIPTION
## Summary

Phase 1 of migrating Dodo to Cloudflare Artifacts (https://blog.cloudflare.com/artifacts-git-for-agents-beta/).

**Status: DRAFT — do not merge until Artifacts private beta access is granted on the jonnyparris account.**

## What this adds

- `ARTIFACTS` binding in `wrangler.jsonc` (namespace_id is a TODO placeholder — fill in once beta grants access)
- Minimal speculative `Artifacts` / `ArtifactsRepo` interfaces in `src/artifacts-types.ts` (replace with `@cloudflare/workers-types` when GA)
- `CodingAgent.getOrCreateArtifactsRepo()` — dormant, not called by any existing handler
- `get_artifacts_remote` MCP tool for debugging
- Hoisted `mockArtifacts` in tests (unused in Phase 1, consumed in Phase 2)

## What this does NOT touch

- File CRUD (read_file / write_file / list_files / search_files)
- Git operations in `src/git.ts`
- Session forking
- isomorphic-git

Those are Phases 2-7 in the adoption plan.

## Verification

- \`npm run typecheck\` — passes
- \`npm test\` — 300 passed, 2 skipped (no regressions)

## Adoption plan

Full phased plan: \`memory/workload/plans/2026-04-16-dodo-artifacts-adoption.md\` in agent-hq.

## Before merging

- [ ] Artifacts private beta access granted on jonnyparris account
- [ ] Replace \`TODO_SET_AFTER_BETA_ACCESS\` in \`wrangler.jsonc\` with real namespace_id
- [ ] Confirm speculative API shapes in \`src/artifacts-types.ts\` match the real binding (docs at https://developers.cloudflare.com/artifacts/)
- [ ] Regenerate types with \`npx wrangler types\` if Artifacts is now in \`@cloudflare/workers-types\`

🤖 Co-authored by Dodo (prompt 042f82dd) + manual typecheck/lint fixes