### PR TITLE
feat: Artifacts migration Phase 2 — shadow-commit stubs [DRAFT]

### DIFF
--- a/src/artifacts-shadow.ts
+++ b/src/artifacts-shadow.ts
@@ -1,0 +1,46 @@
+// Shadow-commit stubs for the Dodo Artifacts migration.
+// Phase 2 wires these hooks into every file-write path. Phase 3 will
+// implement the actual commit body once the Artifacts beta API is
+// documented.
+//
+// See memory/workload/plans/2026-04-16-dodo-artifacts-adoption.md.
+
+import type { ArtifactsRepo } from "./artifacts-types";
+
+export interface ShadowCommitDeps {
+  /** Lazily obtain the Artifacts repo for this session. Returns null if Artifacts is not configured. */
+  getRepo: () => Promise<ArtifactsRepo | null>;
+  /** Log errors without throwing (shadow commits must not break the primary write path). */
+  onError?: (err: unknown, ctx: { op: string; path: string }) => void;
+}
+
+export type ShadowOp = "write" | "replace" | "delete";
+
+/**
+ * Record a file mutation as a commit in the session's Artifacts repo.
+ * This is fire-and-forget and must never throw — a broken Artifacts
+ * shadow must not break the primary workspace write path.
+ */
+export async function shadowCommit(
+  deps: ShadowCommitDeps,
+  op: ShadowOp,
+  path: string,
+  content: string | Uint8Array | null,
+  opts?: { message?: string; authorEmail?: string | null },
+): Promise<void> {
+  try {
+    const repo = await deps.getRepo();
+    if (!repo) return;
+    // TODO(artifacts-beta): implement the actual commit via the Artifacts
+    // REST or binding API once the beta docs confirm the shape. For now
+    // this is a no-op hook that proves the plumbing works.
+    void op;
+    void path;
+    void content;
+    void opts;
+    // Example of what we expect to call later:
+    //   await repo.commit({ path, content, message, author });
+  } catch (err) {
+    deps.onError?.(err, { op, path });
+  }
+}

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1,6 +1,7 @@
 import { Workspace, createWorkspaceStateBackend } from "@cloudflare/shell";
 import { type Connection, type ConnectionContext, type WSMessage } from "agents";
 import type { ArtifactsRepo } from "./artifacts-types";
+import { shadowCommit, type ShadowCommitDeps } from "./artifacts-shadow";
 import { generateText, streamText, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { buildProvider, buildToolsForThink } from "./agentic";
@@ -2098,6 +2099,9 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const path = normalizePath(url.searchParams.get("path") ?? "");
     const body = writeFileSchema.parse(await request.json());
     await this.workspace.writeFile(path, body.content, body.mimeType);
+    await shadowCommit(this.artifactsShadowDeps(), "write", path, body.content, {
+      message: `dodo: write ${path}`,
+    });
     const content = await this.workspace.readFile(path);
     this.emitEvent({ data: { path, type: "write" }, type: "file" });
     return Response.json({ content, path, written: true });
@@ -2107,6 +2111,11 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const path = normalizePath(url.searchParams.get("path") ?? "");
     const body = replaceFileSchema.parse(await request.json());
     const result = await this.stateBackend.replaceInFile(path, body.search, body.replacement);
+    // Shadow-commit the post-replace content. Read-after-write to capture the new state.
+    const replaced = await this.workspace.readFile(path);
+    await shadowCommit(this.artifactsShadowDeps(), "replace", path, replaced, {
+      message: `dodo: replace in ${path}`,
+    });
     this.emitEvent({ data: { path, type: "edit" }, type: "file" });
     return Response.json({ path, result });
   }
@@ -2117,6 +2126,9 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       return Response.json({ error: "Cannot delete workspace root" }, { status: 400 });
     }
     await this.workspace.rm(path, { force: true, recursive: true });
+    await shadowCommit(this.artifactsShadowDeps(), "delete", path, null, {
+      message: `dodo: delete ${path}`,
+    });
     this.emitEvent({ data: { path, type: "delete" }, type: "file" });
     return Response.json({ deleted: true, path });
   }
@@ -3715,6 +3727,21 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       this._artifactsRepo = await this.env.ARTIFACTS.create(name);
     }
     return this._artifactsRepo;
+  }
+
+  private artifactsShadowDeps(): ShadowCommitDeps {
+    return {
+      getRepo: async () => {
+        try {
+          return await this.getOrCreateArtifactsRepo();
+        } catch {
+          return null;
+        }
+      },
+      onError: (err, ctx) => {
+        log("warn", `[artifacts-shadow] ${ctx.op} ${ctx.path} failed`, { err: String(err) });
+      },
+    };
   }
 
   private readMetadata(key: string): string | null {

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -663,3 +663,30 @@ describe("Dodo foundation", () => {
     expect(call[2].tags).toContain("x");
   });
 });
+
+describe("Artifacts shadow commit", () => {
+  it("swallows errors so primary writes don't break", async () => {
+    const { shadowCommit } = await import("../src/artifacts-shadow");
+    const onError = vi.fn();
+    await expect(
+      shadowCommit(
+        {
+          getRepo: async () => { throw new Error("boom"); },
+          onError,
+        },
+        "write",
+        "/foo.txt",
+        "hello",
+      ),
+    ).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][1]).toMatchObject({ op: "write", path: "/foo.txt" });
+  });
+
+  it("is a no-op when no repo is available", async () => {
+    const { shadowCommit } = await import("../src/artifacts-shadow");
+    const getRepo = vi.fn(async () => null);
+    await shadowCommit({ getRepo }, "write", "/foo.txt", "x");
+    expect(getRepo).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the Artifacts migration. Stacked on Phase 1 (PR #5).

**Status: DRAFT — merge order is Phase 1 → Phase 2 → onward. Do not merge until Artifacts private beta access is granted.**

## What this adds

- `src/artifacts-shadow.ts` — `shadowCommit(deps, op, path, content, opts)` with a TODO body. Fire-and-forget contract: must never throw.
- Hooks wired into three write handlers in `src/coding-agent.ts`:
  - `handleWriteFile` — after `workspace.writeFile`, before `emitEvent`
  - `handleReplaceInFile` — after `stateBackend.replaceInFile`, reads post-replace content
  - `handleDeleteFile` — after `workspace.rm`, with `null` content
- `CodingAgent.artifactsShadowDeps()` private helper — delegates to Phase 1's `getOrCreateArtifactsRepo`, catches all errors, returns null rather than throwing
- Two unit tests: error-swallowing, no-op-when-null

## What this does NOT touch

- File CRUD *reads* (Phase 3 — once shadow ledger is populated)
- `src/git.ts` (Phase 5)
- Session forking (Phase 4)
- Clone/fork bulk write paths at lines 2534, 2573 (Phase 3 will use `Artifacts.import()` instead)

## Verification

- \`npm run typecheck\` — passes
- \`npm test\` — 302 passed, 2 skipped (2 new tests added)

## Why shadow commits and not dual-writes

The original plan called for "route reads through Artifacts when enabled" in Phase 2, but that doesn't work because the Artifacts repo starts empty. Writes must populate the ledger first. Shadow-commit every write (fire-and-forget); reads stay on Workspace. Phase 3 switches reads once Artifacts has enough history, or adds lazy backfill.

## Why the commit body is a TODO

The blog post announcement shows `create`, `get`, `import`, and `fork` as binding methods — commits are implicit via `git push`. We'll know the real commit API shape once beta docs land. Phase 3 fills in the TODO body.

## Before merging

- [ ] Phase 1 (PR #5) merged first
- [ ] Artifacts beta access granted, namespace_id set
- [ ] Phase 3 lands to make shadow commits actually persist

🤖 Co-authored by Dodo (session 917f3aa0) — Dodo halted correctly when Phase 1 symbols weren't on main, then couldn't check out the remote ref through its sandbox git tooling, so the code changes landed locally. Lessons captured in agent-hq/memory/learnings.md.