### PR TITLE
fix: drop wrapOutboundWithOwner to fix globalOutbound runtime error

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import type { Workspace } from "@cloudflare/shell";
 import { createWorkspaceGit, defaultAuthor, resolveRemoteToken, verifyRemoteBranch } from "./git";
 import { createBrowserTools } from "./browser/tools";
-import { wrapOutboundWithOwner } from "./executor";
 import type { McpGatekeeper, McpToolInfo } from "./mcp-gatekeeper";
 import { getKnownRepo, listKnownRepos } from "./repos";
 import { createWorkspaceTools, createExecuteTool } from "./think-adapter";
@@ -561,9 +560,7 @@ function buildTools(
   const gitTools = buildGitTools(env, workspace, config, options?.ownerEmail);
 
   if (env.LOADER) {
-    const outbound = options?.ownerId && env.OUTBOUND
-      ? wrapOutboundWithOwner(env.OUTBOUND, options.ownerId)
-      : env.OUTBOUND ?? null;
+    const outbound = env.OUTBOUND ?? null;
 
     tools.codemode = createExecuteTool({
       tools: workspaceTools,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -5,45 +5,39 @@ import type { ExecuteResult } from "@cloudflare/codemode";
 import type { Env } from "./types";
 
 /**
- * Header injected into outbound sandbox requests to identify the session owner.
- * Carries the hex DO ID (not email) so no PII is in transit.
- * AllowlistOutbound reads this to resolve per-user secrets.
+ * Header name for injecting the session owner ID into outbound requests.
+ * Retained for potential future use once per-request owner context is
+ * plumbed through @cloudflare/codemode. Currently unused by runSandboxedCode.
  */
 export const OWNER_ID_HEADER = "x-dodo-owner-id";
-
-/**
- * Wrap an outbound Fetcher to inject the owner's DO ID on every request.
- * AllowlistOutbound strips this header before forwarding.
- */
-export function wrapOutboundWithOwner(outbound: Fetcher, ownerId: string): Fetcher {
-  return {
-    fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
-      const request = new Request(input, init);
-      request.headers.set(OWNER_ID_HEADER, ownerId);
-      return outbound.fetch(request);
-    },
-  } as Fetcher;
-}
 
 export async function runSandboxedCode(input: {
   code: string;
   env: Env;
   workspace: Workspace;
+  // ownerId retained in the signature for caller compatibility, but not
+  // currently wired into the sandbox. Per-request ownership context needs
+  // a WorkerEntrypoint-based injection, not a duck-typed Fetcher wrapper.
+  // TODO: plumb ownerId via AllowlistOutbound reading from a DO-local
+  // request-scoped context, or via an explicit state tool.
   ownerId?: string;
 }): Promise<ExecuteResult> {
   if (!input.env.LOADER) {
     throw new Error("Dynamic Worker loader is not configured");
   }
 
-  const outbound = input.ownerId && input.env.OUTBOUND
-    ? wrapOutboundWithOwner(input.env.OUTBOUND, input.ownerId)
-    : input.env.OUTBOUND ?? null;
+  // Pass the real OUTBOUND ServiceStub directly. The Workers runtime enforces
+  // that globalOutbound must be a Fetcher produced by a service binding —
+  // plain objects cast via `as Fetcher` fail with a type error at runtime.
+  const outbound = input.env.OUTBOUND ?? null;
 
   const executor = new DynamicWorkerExecutor({
     globalOutbound: outbound,
     loader: input.env.LOADER,
     timeout: 30000,
   });
+
+  void input.ownerId; // reserved — see TODO above
 
   return executor.execute(input.code, [resolveProvider(stateTools(input.workspace))]);
 }


### PR DESCRIPTION
## Summary

Fixes #7.

\`dodo_execute_code\` (and \`codemode\` tool via agentic loop) fails at runtime with:

\`\`\`
Incorrect type for the 'globalOutbound' field on 'WorkerCode': the provided value is not of type 'Fetcher'.
\`\`\`

Root cause: \`wrapOutboundWithOwner\` returned a plain JS object cast to \`Fetcher\`. Workers runtime enforces that \`globalOutbound\` must be a real \`ServiceStub\`. The anti-pattern is documented in the repo's own memory patterns file but was reintroduced.

## Changes

- \`src/executor.ts\` — delete \`wrapOutboundWithOwner\`. Pass raw \`env.OUTBOUND\` to \`DynamicWorkerExecutor\`. Retain \`OWNER_ID_HEADER\` export + \`ownerId\` parameter for API compatibility; add TODO comment for proper per-request owner plumbing.
- \`src/agentic.ts\` — remove the second call site in \`buildTools\` that also wrapped \`OUTBOUND\`.

## Verification

- \`npm run typecheck\` — passes
- \`npm test\` — 321 passed, 2 skipped

## Known limitation

\`ownerId\` is now ignored inside the sandbox. Per-request owner context needs a WorkerEntrypoint-based injection (not a duck-typed Fetcher). Tracked in the TODO comment.

🤖 Drafted via \`dodo_dispatch_repo_prompt\` — first successful end-to-end dispatch. Dodo correctly identified the second call site in \`src/agentic.ts\` that my spec missed.