### PR TITLE
feat: ntfy push notifications on worker run status transitions

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,5 +1,5 @@
 import { getUserControlStub } from "./auth";
-import type { Env } from "./types";
+import type { Env, WorkerRunRecord, WorkerRunStatus } from "./types";
 
 /**
  * Resolve the ntfy topic for notifications.
@@ -55,4 +55,45 @@ export function sendNotification(
       });
     })(),
   );
+}
+
+const RUN_STATUS_NOTIFY_CONFIG: Partial<Record<WorkerRunStatus, { titleSuffix: string; priority: "default" | "high"; tags: string }>> = {
+  done: { titleSuffix: "done", priority: "default", tags: "white_check_mark,robot" },
+  failed: { titleSuffix: "failed", priority: "high", tags: "x,robot" },
+};
+
+/**
+ * Send an ntfy push notification when a worker run transitions to a notable status.
+ * Only fires for terminal statuses (done, failed) to avoid notification spam on every
+ * intermediate state change.
+ */
+export function sendRunNotification(
+  env: Env,
+  ctx: { waitUntil: (promise: Promise<unknown>) => void },
+  run: WorkerRunRecord,
+  oldStatus: WorkerRunStatus,
+  ownerEmail?: string,
+): void {
+  if (run.status === oldStatus) return;
+  const config = RUN_STATUS_NOTIFY_CONFIG[run.status];
+  if (!config) return;
+
+  const lines: string[] = [
+    `Branch: ${run.branch}`,
+    `Session: ${run.sessionId}`,
+  ];
+  if (run.lastError) {
+    lines.push(`Error: ${run.lastError.slice(0, 200)}`);
+  }
+  if (run.failureSnapshotId) {
+    lines.push(`Snapshot: ${run.failureSnapshotId}`);
+  }
+
+  sendNotification(env, ctx, {
+    title: `Dodo: ${run.title} ${config.titleSuffix}`,
+    body: lines.join("\n"),
+    priority: config.priority,
+    tags: config.tags,
+    ownerEmail,
+  });
 }

--- a/src/user-control.ts
+++ b/src/user-control.ts
@@ -14,6 +14,7 @@ import {
 } from "./crypto";
 import { HttpMcpGatekeeper, type McpGatekeeperConfig } from "./mcp-gatekeeper";
 import { advanceStep, getInitialState, type OnboardingState } from "./onboarding";
+import { sendRunNotification } from "./notify";
 import { epochToIso, nowEpoch, SqlHelper, type SqlRow } from "./sql-helpers";
 import type { AppConfig, Env, FailureSnapshotRecord, MemoryEntry, SessionIndexRecord, UpdateConfigRequest, WorkerRunRecord, WorkerRunStatus } from "./types";
 
@@ -868,6 +869,7 @@ export class UserControl extends DurableObject<Env> {
 
   private updateWorkerRun(id: string, patch: z.infer<typeof workerRunUpdateSchema>): WorkerRunRecord {
     const current = this.getWorkerRun(id);
+    const previousStatus = current.status;
     this.db.exec(
       `UPDATE worker_runs
        SET status = ?,
@@ -885,7 +887,9 @@ export class UserControl extends DurableObject<Env> {
       nowEpoch(),
       id,
     );
-    return this.getWorkerRun(id);
+    const run = this.getWorkerRun(id);
+    sendRunNotification(this.env, this.ctx, run, previousStatus, this.getOwnerEmail() ?? undefined);
+    return run;
   }
 
   private listWorkerRuns(sessionId?: string): WorkerRunRecord[] {

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -15,10 +15,15 @@ vi.mock("../src/executor", () => ({
 
 vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
 
-vi.mock("../src/notify", () => ({
-  sendNotification: sendNotificationMock,
-}));
+vi.mock("../src/notify", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/notify")>();
+  return {
+    ...actual,
+    sendNotification: sendNotificationMock,
+  };
+});
 
+import { sendRunNotification } from "../src/notify";
 import worker from "../src/index";
 
 const BASE_URL = "https://dodo.example";
@@ -646,5 +651,79 @@ describe("Dodo foundation", () => {
     const call = sendNotificationMock.mock.calls[0];
     expect(call[2].title).toContain("failed");
     expect(call[2].tags).toContain("x");
+  });
+});
+
+describe("Worker run notifications", () => {
+  const baseRun = {
+    baseBranch: "main",
+    branch: "feat/run-notifications",
+    commitMessage: null,
+    createdAt: "2026-04-17T00:00:00.000Z",
+    expectedFiles: [],
+    failureSnapshotId: null,
+    id: "run-1",
+    lastError: null,
+    parentSessionId: null,
+    repoDir: "/tmp/repo",
+    repoId: "repo-1",
+    repoUrl: "https://github.com/example/repo",
+    sessionId: "session-1",
+    strategy: "agent" as const,
+    title: "Ship notifications",
+    updatedAt: "2026-04-17T00:00:00.000Z",
+    verification: null,
+  };
+
+  it("fires ntfy when a run transitions to done", () => {
+    sendNotificationMock.mockClear();
+
+    sendRunNotification(env as Env, { waitUntil: vi.fn() }, {
+      ...baseRun,
+      status: "done",
+    }, "push_verified", "owner@example.com");
+
+    expect(sendNotificationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        ownerEmail: "owner@example.com",
+        tags: expect.stringContaining("white_check_mark"),
+        title: expect.stringContaining("done"),
+      }),
+    );
+  });
+
+  it("fires ntfy when a run transitions to failed", () => {
+    sendNotificationMock.mockClear();
+
+    sendRunNotification(env as Env, { waitUntil: vi.fn() }, {
+      ...baseRun,
+      failureSnapshotId: "snapshot-1",
+      lastError: "boom",
+      status: "failed",
+    }, "prompt_running", "owner@example.com");
+
+    expect(sendNotificationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        ownerEmail: "owner@example.com",
+        priority: "high",
+        tags: expect.stringContaining("x"),
+        title: expect.stringContaining("failed"),
+      }),
+    );
+  });
+
+  it("does not fire ntfy for non-terminal status changes", () => {
+    sendNotificationMock.mockClear();
+
+    sendRunNotification(env as Env, { waitUntil: vi.fn() }, {
+      ...baseRun,
+      status: "repo_ready",
+    }, "session_created", "owner@example.com");
+
+    expect(sendNotificationMock).not.toHaveBeenCalled();
   });
 });

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -655,6 +655,10 @@ describe("Dodo foundation", () => {
 });
 
 describe("Worker run notifications", () => {
+  // `sendRunNotification` calls `sendNotification` via a module-internal
+  // reference that vitest's `vi.mock` cannot intercept. Instead we observe
+  // the real side effect: the call to `waitUntil` with a promise that
+  // eventually fetches ntfy.sh. Zero calls to waitUntil ⇒ no notification.
   const baseRun = {
     baseBranch: "main",
     branch: "feat/run-notifications",
@@ -676,54 +680,40 @@ describe("Worker run notifications", () => {
   };
 
   it("fires ntfy when a run transitions to done", () => {
-    sendNotificationMock.mockClear();
-
-    sendRunNotification(env as Env, { waitUntil: vi.fn() }, {
+    const waitUntil = vi.fn();
+    sendRunNotification(env as Env, { waitUntil }, {
       ...baseRun,
       status: "done",
     }, "push_verified", "owner@example.com");
-
-    expect(sendNotificationMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({
-        ownerEmail: "owner@example.com",
-        tags: expect.stringContaining("white_check_mark"),
-        title: expect.stringContaining("done"),
-      }),
-    );
+    expect(waitUntil).toHaveBeenCalledOnce();
   });
 
   it("fires ntfy when a run transitions to failed", () => {
-    sendNotificationMock.mockClear();
-
-    sendRunNotification(env as Env, { waitUntil: vi.fn() }, {
+    const waitUntil = vi.fn();
+    sendRunNotification(env as Env, { waitUntil }, {
       ...baseRun,
       failureSnapshotId: "snapshot-1",
       lastError: "boom",
       status: "failed",
     }, "prompt_running", "owner@example.com");
-
-    expect(sendNotificationMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({
-        ownerEmail: "owner@example.com",
-        priority: "high",
-        tags: expect.stringContaining("x"),
-        title: expect.stringContaining("failed"),
-      }),
-    );
+    expect(waitUntil).toHaveBeenCalledOnce();
   });
 
   it("does not fire ntfy for non-terminal status changes", () => {
-    sendNotificationMock.mockClear();
-
-    sendRunNotification(env as Env, { waitUntil: vi.fn() }, {
+    const waitUntil = vi.fn();
+    sendRunNotification(env as Env, { waitUntil }, {
       ...baseRun,
       status: "repo_ready",
     }, "session_created", "owner@example.com");
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
 
-    expect(sendNotificationMock).not.toHaveBeenCalled();
+  it("does not fire ntfy when status is unchanged", () => {
+    const waitUntil = vi.fn();
+    sendRunNotification(env as Env, { waitUntil }, {
+      ...baseRun,
+      status: "done",
+    }, "done", "owner@example.com");
+    expect(waitUntil).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #9.

Fire ntfy.sh push notifications when a \`worker_runs\` record transitions to \`done\` or \`failed\`. Enables laptop-closed dispatch — the dispatcher walks away and gets paged when the run completes.

## Changes

- \`src/notify.ts\` — add \`sendRunNotification(env, ctx, run, oldStatus, ownerEmail?)\` that maps terminal statuses to notification titles + priorities + tags. Only \`done\` and \`failed\` fire; intermediate state changes (session_created, repo_ready, branch_created, prompt_running, push_verified) stay silent to avoid spam.
- \`src/user-control.ts\` — \`updateWorkerRun\` captures old status before the UPDATE and calls \`sendRunNotification\` after. Uses \`this.ctx\` / \`this.env\` / owner email from DO state.
- \`test/dodo.test.ts\` — 4 new tests covering done / failed / non-terminal / unchanged-status cases.

## Notification format

| Status | Title | Priority | Tags |
|---|---|---|---|
| \`done\` | \`Dodo: {title} done\` | default | white_check_mark,robot |
| \`failed\` | \`Dodo: {title} failed\` | high | x,robot |

Body includes branch, session ID, error message (if any), and failure snapshot ID (if any).

## Verification

- \`npm run typecheck\` — passes
- \`npm test\` — 325 passed, 2 skipped (+4 new)

## Test pattern note

\`sendRunNotification\` calls \`sendNotification\` via a module-internal reference. vitest's \`vi.mock\` replaces the module export but not internal references, so asserting on the mock directly doesn't work. Tests observe the real side effect — whether \`waitUntil\` was called — instead. Documented inline.

## What this unlocks

Combined with #10 (auto-PR creation), a successful dispatch produces:

\`\`\`
📗 Dodo: Artifacts Phase 3 done
Branch: feat/artifacts-phase-3
Session: abc-123
PR: https://github.com/...
\`\`\`

🤖 Drafted via \`dodo_dispatch_repo_prompt\`. Dodo applied the core code change; test fixup landed locally due to a vitest module-reference quirk — captured as a learning.