### PR TITLE
Artifacts v2 Phase 2: per-turn flush to session repo

### DIFF
--- a/src/artifacts-flush.ts
+++ b/src/artifacts-flush.ts
@@ -1,0 +1,48 @@
+import { createWorkspaceGit } from "./git";
+import { log } from "./logger";
+import type { Workspace } from "@cloudflare/shell";
+
+export interface FlushInput {
+  workspace: Workspace;
+  remote: string;
+  tokenSecret: string;
+  message: string;
+  author?: { name: string; email: string };
+}
+
+/**
+ * Commit all workspace changes and push them to the session's Artifacts remote.
+ * Fire-and-forget: never throws. Returns true if a commit was pushed, false otherwise.
+ */
+export async function flushTurnToArtifacts(input: FlushInput): Promise<boolean> {
+  try {
+    const git = createWorkspaceGit(input.workspace);
+
+    // Ensure the workspace is a git repo. isomorphic-git's init is idempotent.
+    try {
+      await git.status();
+    } catch {
+      await git.init({ defaultBranch: "main" });
+    }
+
+    // Add the artifacts remote if not already configured.
+    const remotes = (await git.remote({ list: true })) as unknown as Array<{ remote: string; url: string }>;
+    if (!remotes.some((r) => r.remote === "artifacts")) {
+      await git.remote({ add: { name: "artifacts", url: input.remote } });
+    }
+
+    // Stage everything, bail if nothing changed.
+    await git.add({ filepath: "." });
+    const status = await git.status();
+    if (status.length === 0) return false;
+
+    // Commit + push.
+    const author = input.author ?? { name: "Dodo", email: "dodo@workers.dev" };
+    await git.commit({ message: input.message, author });
+    await git.push({ remote: "artifacts", ref: "main", token: input.tokenSecret });
+    return true;
+  } catch (err) {
+    log("warn", "[artifacts-flush] failed", { err: String(err) });
+    return false;
+  }
+}

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1,6 +1,7 @@
 import { Workspace, createWorkspaceStateBackend } from "@cloudflare/shell";
 import { type Connection, type ConnectionContext, type WSMessage } from "agents";
 import type { ArtifactsRepo } from "./artifacts-types";
+import { flushTurnToArtifacts } from "./artifacts-flush";
 import { generateText, streamText, type FileUIPart, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { buildProvider, buildToolsForThink } from "./agentic";
@@ -3167,6 +3168,20 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     };
 
     await this.chat(userMsg, callback, { signal: options?.signal });
+
+    // Flush workspace changes to Artifacts. Fire-and-forget — never blocks the turn.
+    const artifactsCtx = await this.getOrCreateArtifactsContext().catch(() => null);
+    if (artifactsCtx) {
+      void flushTurnToArtifacts({
+        workspace: this.workspace,
+        remote: artifactsCtx.remote,
+        tokenSecret: artifactsCtx.tokenSecret,
+        message: `dodo: turn ${new Date().toISOString()}`,
+        author: options?.authorEmail
+          ? { name: options.authorEmail, email: options.authorEmail }
+          : { name: "Dodo", email: "dodo@workers.dev" },
+      });
+    }
 
     // If the stream contained an error chunk that Think silently dropped,
     // throw it so the caller (runFiberPrompt) can surface it properly.

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -73,6 +73,20 @@ async function eventually(assertion: () => Promise<void>, attempts = 20): Promis
   throw lastError;
 }
 
+describe("Artifacts flush", () => {
+  it("swallows errors silently", async () => {
+    const { flushTurnToArtifacts } = await import("../src/artifacts-flush");
+    const workspace = {} as any;
+    const result = await flushTurnToArtifacts({
+      workspace,
+      remote: "https://fake",
+      tokenSecret: "tok",
+      message: "test",
+    });
+    expect(result).toBe(false);
+  });
+});
+
 describe("Dodo foundation", () => {
   beforeAll(async () => {
     for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
## Summary

Auto-generated by Dodo worker run `9e8e44de-1769-43ee-9aa8-9c8e76ac30f2`.

feat: flush workspace changes to Artifacts at end of each agent turn

## Metadata

- Branch: `feat/artifacts-v2-phase-2`
- Base: `main`
- Session: `ebd2282c-0bee-43b5-be60-48e33924fd34`
- Strategy: `agent`
- Verification: `{"aheadBy":1,"baseRef":"main","branch":"feat/artifacts-v2-phase-2","changedFiles":["src/artifacts-flush.ts","src/coding-agent.ts","test/dodo.test.ts"],"compareUrl":"https://api.github.com/repos/jonnyparris/dodo/compare/main...feat%2Fartifacts-v2-phase-2","ok":true,"provider":"github","remoteUrl":"https://github.com/jonnyparris/dodo"}`

---

🤖 Drafted via `dodo_dispatch_repo_prompt`.