### PR TITLE
feat: render images in chat — screenshots, model-generated, user-uploaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,17 @@ Per-user key-value store with text search, persistent across sessions. Your agen
 
 ### Browser
 
-Headless Chrome via Cloudflare Browser Rendering. Full CDP (Chrome DevTools Protocol) access through two code-mode tools: `browser_search` (query the CDP spec) and `browser_execute` (run CDP commands). The agent can navigate pages, read documentation, fill forms, and scrape data.
+Headless Chrome via Cloudflare Browser Rendering. Full CDP (Chrome DevTools Protocol) access through two code-mode tools: `browser_search` (query the CDP spec) and `browser_execute` (run CDP commands). The agent can navigate pages, read documentation, fill forms, and scrape data. Screenshots captured via `Page.captureScreenshot` render inline in the chat — see Attachments below.
+
+### Attachments (images in chat)
+
+Images surface in the chat from three sources and flow through the same R2-backed pipeline:
+
+- **User uploads** -- Paste an image or click the paperclip to send a screenshot to a multimodal model (Claude, Gemini, GPT-4o, Gemma). Limits: 5 images per message, 3MB raw per image, PNG/JPEG/GIF/WebP.
+- **Browser tool screenshots** -- `browser_execute` extracts screenshots from the CDP result, stashes them in R2, and returns a short text summary to the model (so base64 doesn't burn context). Images render inline on the tool-result bubble.
+- **Model-generated images** -- Responses from image-generating models (e.g. Gemini imagen, Gemma vision) are captured during the stream, uploaded to R2, and rendered on the assistant bubble.
+
+**Storage:** Attachments live in the `dodo-workspaces` R2 bucket under the `attachments/{sessionId}/{messageId}/` prefix. Run `scripts/setup-attachment-lifecycle.sh` once per account to install the **30-day auto-expiry** lifecycle rule (lifecycle rules aren't yet configurable via `wrangler.jsonc`). Access is ACL-gated via the existing `/session/:id/*` ownership middleware — if you can't read the session, you can't read its attachments.
 
 ### Orchestration
 

--- a/public/js/dodo-chat.js
+++ b/public/js/dodo-chat.js
@@ -178,6 +178,38 @@ function connectSSE(id){
     renderToolCall(JSON.parse(e.data));loadFilesDebounced();
   });
 
+  // tool_result fires when a tool finishes and may carry image attachments
+  // (e.g. browser_execute screenshots). Updates the in-flight tool_call
+  // bubble in place with the output + any images.
+  eventSource.addEventListener("tool_result",(e)=>{
+    resetSseActivityTimer();
+    try{updateToolCallResult(JSON.parse(e.data))}catch{}
+    loadFilesDebounced();
+  });
+
+  // tool_attachments fires as soon as a tool extracts and uploads images to
+  // R2, before the tool output itself arrives on tool_result. We attach the
+  // images to the tool bubble early for snappy UX.
+  eventSource.addEventListener("tool_attachments",(e)=>{
+    resetSseActivityTimer();
+    try{
+      const data=JSON.parse(e.data);
+      const entry=_toolCallBubbles.get(data.toolCallId);
+      if(entry)_appendAttachmentImages(entry.el,data.attachments);
+    }catch{}
+  });
+
+  // message_attachments fires when the assistant generates images (Gemma,
+  // Gemini imagen, etc.) — the text streams first, then the finalised image
+  // references arrive. Attach them to the already-rendered bubble.
+  eventSource.addEventListener("message_attachments",(e)=>{
+    resetSseActivityTimer();
+    try{
+      const data=JSON.parse(e.data);
+      attachImagesToMessage(data.messageId,data.attachments);
+    }catch{}
+  });
+
   eventSource.addEventListener("file",()=>loadFilesDebounced());
   eventSource.addEventListener("prompt",(e)=>{
     refreshGit();
@@ -231,8 +263,32 @@ async function cancelQueued(queueId,btn){
   const el=btn.closest('.msg.queued');if(el)el.remove();
 }
 
+// Render an image attachment list into a container element. Used both on
+// message bubbles (user uploads, assistant-generated images, tool screenshots)
+// and on inline tool_call bubbles. `url` may be a data URL (inline fallback)
+// or a served path like /session/:id/attachment/... — we just trust the
+// server-provided URL and only block the one footgun case (inline data URLs
+// that aren't images).
+function _appendAttachmentImages(container, attachments){
+  if(!attachments||!attachments.length)return;
+  const wrap=document.createElement("div");wrap.className="msg-attachment";
+  attachments.forEach((a,i)=>{
+    if(!a||typeof a.url!=="string")return;
+    if(a.url.startsWith("data:")&&!a.url.startsWith("data:image/"))return;
+    const img=document.createElement("img");
+    img.src=a.url;
+    img.alt=`Attachment ${i+1} of ${attachments.length}`;
+    img.loading="lazy";
+    img.onclick=()=>window.open(a.url,"_blank","noopener,noreferrer");
+    img.style.cursor="zoom-in";
+    wrap.appendChild(img);
+  });
+  if(wrap.childElementCount>0)container.appendChild(wrap);
+}
+
 function renderMessage(msg){
   const el=document.createElement("div");el.className=`msg ${msg.role}`;
+  if(msg.id)el.dataset.msgId=msg.id;
   if(msg.role==="assistant"){
     el.innerHTML=renderMarkdown(msg.content);
     el.querySelectorAll('pre').forEach(pre=>{
@@ -240,6 +296,10 @@ function renderMessage(msg){
       btn.onclick=(e)=>{e.stopPropagation();const code=pre.querySelector('code')?.textContent||pre.textContent;navigator.clipboard.writeText(code).then(()=>{btn.textContent='Copied!';setTimeout(()=>btn.textContent='Copy',1500)})};
       pre.style.position='relative';pre.appendChild(btn);
     });
+    // Assistant bubbles can also carry attachments — model-generated images
+    // from Gemini/Gemma, or screenshots surfaced via the assistant's final
+    // tool-result summary.
+    _appendAttachmentImages(el,msg.attachments);
   }else{
     const authorEmail=msg.authorEmail||msg.author||msg.email||null;
     const label=document.createElement("div");
@@ -249,15 +309,7 @@ function renderMessage(msg){
     }else{label.style.color="rgba(255,255,255,.75)";label.textContent="You"}
     el.appendChild(label);
     el.appendChild(document.createTextNode(msg.content));
-    if(msg.attachments&&msg.attachments.length){
-      const imgWrap=document.createElement("div");imgWrap.className="msg-attachment";
-      msg.attachments.forEach(a=>{
-        if(!a.url.startsWith("data:image/"))return;
-        const img=document.createElement("img");img.src=a.url;img.alt="attachment";img.loading="lazy";
-        imgWrap.appendChild(img);
-      });
-      el.appendChild(imgWrap);
-    }
+    _appendAttachmentImages(el,msg.attachments);
   }
   const actions=document.createElement("div");actions.className="msg-actions";
   const copyBtn=document.createElement("button");copyBtn.textContent="Copy";copyBtn.title="Copy message";copyBtn.setAttribute("aria-label","Copy message");
@@ -266,22 +318,84 @@ function renderMessage(msg){
   if(msg.role==="assistant"&&(msg.tokenInput||msg.tokenOutput)){const m=document.createElement("div");m.style.cssText="font-size:10px;color:var(--muted);margin-top:6px;opacity:.7";m.textContent=`${msg.tokenInput??0} in / ${msg.tokenOutput??0} out`;el.appendChild(m)}
   $("chat").appendChild(el);_smoothScrollToBottom()
 }
+// Track in-flight tool calls so tool_result events can enrich the same bubble
+// rather than creating a new one. Keyed by toolCallId.
+const _toolCallBubbles=new Map();
+
 function renderToolCall(tc){
+  // tc may come from the legacy single-event form (code+result) or the new
+  // tool_call event (toolCallId + toolName + input). We render the "call has
+  // started" state; tool_result updates the same bubble when output arrives.
   const el=document.createElement("div");el.className="msg tool_call";
-  const hasResult=tc.result!=null&&tc.result!=="null"&&JSON.stringify(tc.result)!=="null";
-  const resultStr=hasResult?JSON.stringify(tc.result,null,2):"null";
-  const truncated=resultStr.length>500;
-  const details=document.createElement("details");
-  const summary=document.createElement("summary");summary.textContent="Tool call";details.appendChild(summary);
-  const pre=document.createElement("pre");pre.style.cssText="margin:6px 0 0;font-size:11px;white-space:pre-wrap;max-height:200px;overflow:auto";pre.textContent=tc.code||"";details.appendChild(pre);
-  const resultDiv=document.createElement("div");resultDiv.style.cssText="margin-top:4px;font-size:11px;color:var(--muted)";resultDiv.textContent=hasResult?"Result: "+(truncated?resultStr.slice(0,500)+"...":resultStr):"\u2713 Done";details.appendChild(resultDiv);
-  if(truncated){
-    const expandBtn=document.createElement("button");expandBtn.className="sm";expandBtn.style.marginTop="4px";expandBtn.textContent="Show full result";
-    expandBtn.onclick=()=>{resultDiv.textContent="Result: "+resultStr;expandBtn.remove()};
-    details.appendChild(expandBtn);
+  if(tc.toolCallId)el.dataset.toolCallId=tc.toolCallId;
+  const details=document.createElement("details");details.open=false;
+  const summary=document.createElement("summary");
+  const toolName=tc.toolName||tc.name||"tool";
+  summary.textContent=`${toolName} \u2026`;
+  details.appendChild(summary);
+  // Show the tool input (args) if present — for code-mode tools this is the
+  // actual JS that ran. Legacy event shape put this in `code`.
+  const inputText=tc.code||(tc.input?JSON.stringify(tc.input,null,2):"");
+  if(inputText){
+    const pre=document.createElement("pre");
+    pre.style.cssText="margin:6px 0 0;font-size:11px;white-space:pre-wrap;max-height:200px;overflow:auto";
+    pre.textContent=inputText;
+    details.appendChild(pre);
   }
+  // Placeholder for the result — filled in by updateToolCallResult.
+  const resultDiv=document.createElement("div");
+  resultDiv.className="tool-result-body";
+  resultDiv.style.cssText="margin-top:4px;font-size:11px;color:var(--muted)";
+  resultDiv.textContent="Running\u2026";
+  details.appendChild(resultDiv);
   el.appendChild(details);
+  // Legacy callers pass `result` directly on the call event — render once.
+  if(tc.result!=null){
+    _fillToolResult(el,summary,resultDiv,{output:tc.result,attachments:tc.attachments});
+  }else if(tc.toolCallId){
+    _toolCallBubbles.set(tc.toolCallId,{el,summary,resultDiv,toolName});
+  }
   $("chat").appendChild(el);_smoothScrollToBottom()
+}
+
+function updateToolCallResult(tr){
+  if(!tr||!tr.toolCallId)return;
+  const entry=_toolCallBubbles.get(tr.toolCallId);
+  if(!entry){
+    // Result arrived with no matching call bubble — render it fresh so the
+    // image/output is still visible.
+    renderToolCall({toolCallId:tr.toolCallId,toolName:tr.toolName,result:tr.output,attachments:tr.attachments});
+    return;
+  }
+  _fillToolResult(entry.el,entry.summary,entry.resultDiv,tr);
+  _toolCallBubbles.delete(tr.toolCallId);
+}
+
+function _fillToolResult(el,summary,resultDiv,tr){
+  const output=tr.output;
+  const outputStr=typeof output==="string"?output:JSON.stringify(output,null,2);
+  const hasResult=outputStr!=null&&outputStr!=="null"&&outputStr!=="";
+  const truncated=hasResult&&outputStr.length>500;
+  summary.textContent=`${summary.textContent.replace(/\s*\u2026$/,"")} \u2713`;
+  resultDiv.textContent=hasResult?"Result: "+(truncated?outputStr.slice(0,500)+"...":outputStr):"\u2713 Done";
+  if(truncated){
+    const expandBtn=document.createElement("button");
+    expandBtn.className="sm";expandBtn.style.marginTop="4px";expandBtn.textContent="Show full result";
+    expandBtn.onclick=()=>{resultDiv.textContent="Result: "+outputStr;expandBtn.remove()};
+    resultDiv.parentElement.appendChild(expandBtn);
+  }
+  // Render any image attachments the tool produced (screenshots).
+  _appendAttachmentImages(el,tr.attachments);
+}
+
+// Attach images to an already-rendered message bubble by id. Used when the
+// stream emits `message_attachments` (assistant-generated images) after the
+// message bubble has already been painted from the text stream.
+function attachImagesToMessage(messageId,attachments){
+  if(!messageId||!attachments||!attachments.length)return;
+  const el=$("chat").querySelector(`.msg[data-msg-id="${CSS.escape(messageId)}"]`);
+  if(!el)return;
+  _appendAttachmentImages(el,attachments);
 }
 function setStatusDot(status){$("session-status-dot").className=`status-dot ${status==="running"?"running":"idle"}`}
 function updateTokenSummary(state){

--- a/scripts/setup-attachment-lifecycle.sh
+++ b/scripts/setup-attachment-lifecycle.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Apply a 30-day expiration lifecycle rule to chat attachment objects in
+# the `dodo-workspaces` R2 bucket. Run once per environment (dev/prod) to
+# provision auto-cleanup.
+#
+# Attachments are stored under the `attachments/` prefix by
+# src/attachments.ts. Workspace files (project code) live elsewhere in the
+# bucket and are untouched by this rule.
+#
+# Usage:
+#   ./scripts/setup-attachment-lifecycle.sh
+#
+# Requires: wrangler logged in with R2 permissions for the target account.
+
+set -euo pipefail
+
+BUCKET_NAME="${BUCKET_NAME:-dodo-workspaces}"
+RULE_ID="attachments-30d-expire"
+PREFIX="attachments/"
+EXPIRE_DAYS=30
+
+echo "Applying lifecycle rule to R2 bucket: $BUCKET_NAME"
+echo "  Rule: $RULE_ID"
+echo "  Prefix: $PREFIX"
+echo "  Expire after: $EXPIRE_DAYS days"
+
+# Positional args: bucket, name, prefix
+npx wrangler r2 bucket lifecycle add "$BUCKET_NAME" "$RULE_ID" "$PREFIX" \
+  --expire-days "$EXPIRE_DAYS" \
+  --force
+
+echo
+echo "Current rules on $BUCKET_NAME:"
+npx wrangler r2 bucket lifecycle list "$BUCKET_NAME"

--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -3,12 +3,31 @@ import type { StateBackend } from "@cloudflare/shell";
 import { generateText, jsonSchema, stepCountIs, tool, zodSchema, type Tool as AnyToolType } from "ai";
 import { z } from "zod";
 import type { Workspace } from "@cloudflare/shell";
+import type { AttachmentRef } from "./attachments";
 import { createWorkspaceGit, defaultAuthor, resolveRemoteToken, verifyRemoteBranch } from "./git";
 import { createBrowserTools } from "./browser/tools";
 import type { McpGatekeeper, McpToolInfo } from "./mcp-gatekeeper";
 import { getKnownRepo, listKnownRepos } from "./repos";
 import { createWorkspaceTools, createExecuteTool } from "./think-adapter";
 import type { AppConfig, Env } from "./types";
+
+/** Options passed through from the coding agent into tool factories. */
+export interface BuildToolsOptions {
+  authorEmail?: string;
+  browserEnabled?: boolean;
+  isAdminUser?: boolean;
+  ownerId?: string;
+  ownerEmail?: string;
+  stateBackend?: StateBackend;
+  /** Session ID — required to scope attachment R2 keys. */
+  sessionId?: string;
+  /**
+   * Fires when a tool produces image attachments. The coding agent uses this
+   * to stream `tool_result_image` SSE events so the chat UI renders screenshots
+   * before the assistant message finishes persisting.
+   */
+  onToolAttachments?: (toolCallId: string, attachments: AttachmentRef[]) => void;
+}
 
 // ─── Tool Output Caps (OpenCode Pattern #1) ───
 // Cap tool output AT THE TOOL LEVEL before it enters the AI SDK message history.
@@ -552,7 +571,7 @@ function buildTools(
   env: Env,
   workspace: Workspace,
   config: AppConfig,
-  options?: { authorEmail?: string; browserEnabled?: boolean; isAdminUser?: boolean; ownerId?: string; ownerEmail?: string; stateBackend?: StateBackend },
+  options?: BuildToolsOptions,
 ): Record<string, AnyTool> {
   const tools: Record<string, AnyTool> = {};
 
@@ -621,6 +640,10 @@ function buildTools(
       browser: env.BROWSER,
       loader: env.LOADER,
       timeout: 30_000,
+      env,
+      sessionId: options?.sessionId,
+      ownerEmail: options?.ownerEmail,
+      onAttachments: options?.onToolAttachments,
     });
     Object.assign(tools, browserTools);
   }
@@ -636,7 +659,7 @@ export function buildToolsForThink(
   env: Env,
   workspace: Workspace,
   config: AppConfig,
-  options?: { authorEmail?: string; browserEnabled?: boolean; isAdminUser?: boolean; ownerId?: string; ownerEmail?: string; stateBackend?: StateBackend; mcpGatekeepers?: McpGatekeeper[] },
+  options?: BuildToolsOptions & { mcpGatekeepers?: McpGatekeeper[] },
 ): Record<string, AnyTool> {
   const tools = buildTools(env, workspace, config, options);
 

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,0 +1,231 @@
+/**
+ * Attachment storage and helpers.
+ *
+ * Images surface in chat from three sources — user uploads, browser tool
+ * screenshots, and assistant-generated images from vision/imagen models.
+ * All three land here: base64 payload → R2 object → short `dodo-attachment://`
+ * URL that the frontend rewrites to a session-scoped GET route.
+ *
+ * Why R2 (not inline in SQLite):
+ *   - Screenshots are 100KB–2MB each. Keeping them in message history bloats
+ *     every `/session/:id/messages` query and Think's compaction will replace
+ *     them with placeholder text anyway (see enforceRowSizeLimit in Think).
+ *   - R2 lifecycle rules handle cleanup — attachments auto-expire after 30
+ *     days (see wrangler.jsonc `lifecycle_rules`).
+ *
+ * Why not a signed URL:
+ *   - The worker already gates `/session/:id/*` on session permission, so
+ *     a route-level check (`attachment/:key`) is the natural place to ACL.
+ *   - Signed URLs would leak past the 30-day window and need key rotation.
+ */
+
+import type { Env } from "./types";
+
+const ATTACHMENT_URL_SCHEME = "dodo-attachment://";
+const ATTACHMENT_KEY_PREFIX = "attachments/";
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10MB per attachment
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
+const EXT_TO_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+export interface AttachmentRef {
+  mediaType: string;
+  /** dodo-attachment://{sessionId}/{messageId}/{attachmentId}.{ext} */
+  url: string;
+  /** Byte size after base64 decode. */
+  size: number;
+}
+
+export function isAttachmentUrl(url: string): boolean {
+  return url.startsWith(ATTACHMENT_URL_SCHEME);
+}
+
+/**
+ * Build the R2 key for a `dodo-attachment://` URL. Returns null if the URL
+ * is not a dodo-attachment URL or is malformed.
+ */
+export function attachmentUrlToKey(url: string): string | null {
+  if (!isAttachmentUrl(url)) return null;
+  const path = url.slice(ATTACHMENT_URL_SCHEME.length);
+  // Expect sessionId/messageId/attachmentId.ext
+  const segments = path.split("/");
+  if (segments.length !== 3) return null;
+  const [sessionId, messageId, filename] = segments;
+  // Basic slug check — no traversal, no empty segments.
+  if (!sessionId || !messageId || !filename) return null;
+  if (sessionId.includes("..") || messageId.includes("..") || filename.includes("..")) return null;
+  return `${ATTACHMENT_KEY_PREFIX}${sessionId}/${messageId}/${filename}`;
+}
+
+/**
+ * Extract the session ID from a dodo-attachment URL. Used by the serving
+ * route to cross-check that the requester's session permission actually
+ * covers the session the attachment belongs to.
+ */
+export function attachmentUrlToSessionId(url: string): string | null {
+  if (!isAttachmentUrl(url)) return null;
+  const path = url.slice(ATTACHMENT_URL_SCHEME.length);
+  const segments = path.split("/");
+  if (segments.length !== 3) return null;
+  return segments[0] || null;
+}
+
+/** Build a public-facing HTTP path for a dodo-attachment URL. */
+export function attachmentUrlToHttpPath(url: string): string | null {
+  const sessionId = attachmentUrlToSessionId(url);
+  const key = attachmentUrlToKey(url);
+  if (!sessionId || !key) return null;
+  // /session/:id/attachment/{messageId}/{filename}
+  const stripped = key.slice(`${ATTACHMENT_KEY_PREFIX}${sessionId}/`.length);
+  return `/session/${sessionId}/attachment/${stripped}`;
+}
+
+/**
+ * Decode base64 to a Uint8Array. Throws if the input isn't valid base64.
+ * Keeps the hot path small — no chunking since we cap at MAX_ATTACHMENT_BYTES.
+ */
+function decodeBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export interface UploadAttachmentInput {
+  sessionId: string;
+  messageId: string;
+  mediaType: string;
+  /** Either raw base64 or a data URL — we'll strip the prefix if present. */
+  data: string;
+  /** Optional: email of the user whose session this is, for audit. */
+  ownerEmail?: string;
+  /** Optional: what produced this attachment (user/tool/assistant). */
+  source?: "user" | "tool" | "assistant";
+  /** Optional: tool name if source is "tool". */
+  toolName?: string;
+}
+
+/**
+ * Upload an image attachment to R2 and return a dodo-attachment:// URL.
+ *
+ * If R2 is unavailable (local dev without the binding), returns null and
+ * the caller should fall back to inlining the data URL. This keeps the
+ * feature working in environments without R2 without crashing.
+ */
+export async function uploadAttachment(
+  env: Env,
+  input: UploadAttachmentInput,
+): Promise<AttachmentRef | null> {
+  if (!env.WORKSPACE_BUCKET) return null;
+  const ext = MIME_TO_EXT[input.mediaType];
+  if (!ext) return null; // Unsupported media type — refuse rather than store garbage
+
+  // Strip data URL prefix if present
+  const base64 = input.data.startsWith("data:")
+    ? input.data.slice(input.data.indexOf(",") + 1)
+    : input.data;
+
+  let bytes: Uint8Array;
+  try {
+    bytes = decodeBase64(base64);
+  } catch {
+    return null;
+  }
+  if (bytes.length > MAX_ATTACHMENT_BYTES) return null;
+
+  const attachmentId = crypto.randomUUID();
+  const filename = `${attachmentId}.${ext}`;
+  const key = `${ATTACHMENT_KEY_PREFIX}${input.sessionId}/${input.messageId}/${filename}`;
+
+  await env.WORKSPACE_BUCKET.put(key, bytes, {
+    httpMetadata: { contentType: input.mediaType },
+    customMetadata: {
+      sessionId: input.sessionId,
+      messageId: input.messageId,
+      mediaType: input.mediaType,
+      source: input.source ?? "unknown",
+      ...(input.toolName ? { toolName: input.toolName } : {}),
+      ...(input.ownerEmail ? { ownerEmail: input.ownerEmail } : {}),
+    },
+  });
+
+  return {
+    mediaType: input.mediaType,
+    url: `${ATTACHMENT_URL_SCHEME}${input.sessionId}/${input.messageId}/${filename}`,
+    size: bytes.length,
+  };
+}
+
+/**
+ * Fetch an attachment from R2 by its HTTP path segment
+ * ({messageId}/{filename}). Returns null if not found or media type mismatches.
+ */
+export async function fetchAttachment(
+  env: Env,
+  sessionId: string,
+  messageAndFile: string,
+): Promise<Response | null> {
+  if (!env.WORKSPACE_BUCKET) return null;
+  // Defensive: block traversal
+  if (messageAndFile.includes("..") || messageAndFile.startsWith("/")) return null;
+  const segments = messageAndFile.split("/");
+  if (segments.length !== 2) return null;
+  const [messageId, filename] = segments;
+  if (!messageId || !filename) return null;
+
+  // Only serve known extensions
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  const mediaType = EXT_TO_MIME[ext];
+  if (!mediaType) return null;
+
+  const key = `${ATTACHMENT_KEY_PREFIX}${sessionId}/${messageId}/${filename}`;
+  const obj = await env.WORKSPACE_BUCKET.get(key);
+  if (!obj) return null;
+
+  return new Response(obj.body, {
+    headers: {
+      "content-type": obj.httpMetadata?.contentType ?? mediaType,
+      "cache-control": "private, max-age=3600",
+      etag: obj.httpEtag,
+    },
+  });
+}
+
+/**
+ * Rewrite `dodo-attachment://` URLs in a list of attachments to the
+ * public `/session/:id/attachment/...` HTTP path so the frontend can load
+ * them directly. Non-attachment URLs (e.g. inline data URLs, external URLs)
+ * pass through unchanged.
+ */
+export function rewriteAttachmentsForClient<T extends { url: string }>(
+  attachments: T[] | undefined,
+): T[] | undefined {
+  if (!attachments) return attachments;
+  return attachments.map((a) => {
+    const httpPath = attachmentUrlToHttpPath(a.url);
+    if (!httpPath) return a;
+    return { ...a, url: httpPath };
+  });
+}
+
+/** Exposed for tests. */
+export const _internals = {
+  ATTACHMENT_URL_SCHEME,
+  ATTACHMENT_KEY_PREFIX,
+  MAX_ATTACHMENT_BYTES,
+  MIME_TO_EXT,
+  EXT_TO_MIME,
+};

--- a/src/browser/tools.ts
+++ b/src/browser/tools.ts
@@ -4,6 +4,8 @@ import type { ResolvedProvider } from "@cloudflare/codemode";
 import { z } from "zod";
 import { CdpSession, connectBrowser } from "./cdp-session";
 import { truncateResponse } from "./truncate";
+import { uploadAttachment, type AttachmentRef } from "../attachments";
+import type { Env } from "../types";
 import spec from "./data/cdp/spec.json";
 import summary from "./data/cdp/summary.json";
 import { CDP_DOMAINS } from "./data/cdp/domains";
@@ -15,6 +17,19 @@ export interface BrowserToolsOptions {
   loader: WorkerLoader;
   /** Execution timeout in ms (default: 30000) */
   timeout?: number;
+  /**
+   * Callback fired when a tool result contained image data that was
+   * extracted, uploaded to R2, and replaced with attachment references.
+   * Used by the coding agent to stream image events to the chat UI
+   * before the assistant message finishes persisting.
+   */
+  onAttachments?: (toolCallId: string, attachments: AttachmentRef[]) => void;
+  /** Full worker env — required for R2 attachment uploads. */
+  env?: Env;
+  /** Session ID — required for R2 attachment key scoping. */
+  sessionId?: string;
+  /** Owner email — stored as R2 custom metadata for audit. */
+  ownerEmail?: string;
 }
 
 const SEARCH_DESCRIPTION = `Search the Chrome DevTools Protocol spec using JavaScript code.
@@ -100,6 +115,73 @@ function formatError(error: unknown): string {
 }
 
 /**
+ * Walk the CDP tool result tree and find objects that look like screenshots.
+ * Returns the list of matches along with a cloned tree that has the base64
+ * payloads stripped — we don't want to feed megabytes of base64 back to the
+ * model as tool output text.
+ *
+ * Shapes recognised:
+ *   - Raw CDP Page.captureScreenshot response: { data: "base64...", format: "png" }
+ *   - Author-returned docstring shape: { screenshot: "base64...", format: "png" }
+ */
+interface ExtractedImage {
+  data: string;
+  mediaType: string;
+}
+interface ExtractResult {
+  images: ExtractedImage[];
+  scrubbed: unknown;
+}
+
+const SCREENSHOT_FORMATS = new Set(["png", "jpeg", "webp"]);
+// Base64 lower bound for treating a string as a screenshot payload. A PNG
+// header is already ~24 base64 chars; 50 is safely past "accidentally looks
+// like a format hint" territory without excluding tiny test fixtures.
+const MIN_SCREENSHOT_BASE64_LENGTH = 50;
+
+function extractScreenshotsInPlace(value: unknown, images: ExtractedImage[]): unknown {
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => extractScreenshotsInPlace(v, images));
+  }
+  const obj = value as Record<string, unknown>;
+  const format = typeof obj.format === "string" ? obj.format.toLowerCase() : null;
+  // Raw CDP shape: { data, format: "png"|"jpeg"|"webp" }
+  if (
+    format && SCREENSHOT_FORMATS.has(format) &&
+    typeof obj.data === "string" && obj.data.length >= MIN_SCREENSHOT_BASE64_LENGTH
+  ) {
+    images.push({ data: obj.data, mediaType: `image/${format === "jpeg" ? "jpeg" : format}` });
+    const { data: _data, ...rest } = obj;
+    return { ...rest, _attachmentPlaceholder: true };
+  }
+  // Docstring shape: { screenshot, format }
+  if (
+    format && SCREENSHOT_FORMATS.has(format) &&
+    typeof obj.screenshot === "string" && obj.screenshot.length >= MIN_SCREENSHOT_BASE64_LENGTH
+  ) {
+    images.push({
+      data: obj.screenshot,
+      mediaType: `image/${format === "jpeg" ? "jpeg" : format}`,
+    });
+    const { screenshot: _screenshot, ...rest } = obj;
+    return { ...rest, _attachmentPlaceholder: true };
+  }
+  // Recurse into plain objects
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    result[k] = extractScreenshotsInPlace(v, images);
+  }
+  return result;
+}
+
+export function extractScreenshots(value: unknown): ExtractResult {
+  const images: ExtractedImage[] = [];
+  const scrubbed = extractScreenshotsInPlace(value, images);
+  return { images, scrubbed };
+}
+
+/**
  * Create AI SDK tools for browser automation via CDP code mode.
  *
  * Returns `browser_search` (query the CDP spec) and `browser_execute`
@@ -145,7 +227,7 @@ export function createBrowserTools(options: BrowserToolsOptions): Record<string,
       inputSchema: z.object({
         code: z.string().describe("JavaScript async arrow function that uses the cdp helper"),
       }),
-      execute: async ({ code }: { code: string }) => {
+      execute: async ({ code }: { code: string }, execOptions: { toolCallId: string }) => {
         let session: CdpSession | undefined;
         try {
           session = await connectBrowser(options.browser);
@@ -176,6 +258,48 @@ export function createBrowserTools(options: BrowserToolsOptions): Record<string,
           const result = await executor.execute(code, providers);
           if (result.error) {
             return { error: result.error };
+          }
+
+          // Pull screenshots out of the result before stringifying — base64
+          // blobs should not go back to the LLM as tool-output text (wastes
+          // context) nor get persisted in the message row (Think's compaction
+          // would replace them with placeholder text anyway).
+          const { images, scrubbed } = extractScreenshots(result.result);
+          if (images.length > 0 && options.env && options.sessionId) {
+            const uploaded: AttachmentRef[] = [];
+            for (const img of images) {
+              const ref = await uploadAttachment(options.env, {
+                sessionId: options.sessionId,
+                // toolCallId buckets attachments per tool invocation. Using
+                // this instead of a messageId means they are linkable before
+                // the assistant message has finished persisting.
+                messageId: `toolcall-${execOptions.toolCallId}`,
+                mediaType: img.mediaType,
+                data: img.data,
+                ownerEmail: options.ownerEmail,
+                source: "tool",
+                toolName: "browser_execute",
+              });
+              if (ref) uploaded.push(ref);
+            }
+            if (uploaded.length > 0) {
+              options.onAttachments?.(execOptions.toolCallId, uploaded);
+              // Give the model a short, useful summary — it knows a screenshot
+              // exists and is rendered in the chat, but doesn't burn tokens
+              // re-reading the base64.
+              const scrubbedText = truncateResponse(scrubbed);
+              const refs = uploaded
+                .map((r, i) =>
+                  `  ${i + 1}. ${r.mediaType} (${Math.round(r.size / 1024)}KB) — ${r.url}`,
+                )
+                .join("\n");
+              return [
+                scrubbedText,
+                "",
+                `[${uploaded.length} screenshot${uploaded.length === 1 ? "" : "s"} captured and rendered inline in the chat — base64 data stripped from this tool output to conserve context. The user sees the image${uploaded.length === 1 ? "" : "s"} above.]`,
+                refs,
+              ].join("\n");
+            }
           }
           return truncateResponse(result.result);
         } catch (error) {

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -3,6 +3,8 @@ import { type Connection, type ConnectionContext, type WSMessage } from "agents"
 import { generateText, streamText, type FileUIPart, type LanguageModel, type ModelMessage, type ToolSet } from "ai";
 import { z } from "zod";
 import { buildProvider, buildToolsForThink } from "./agentic";
+import type { AttachmentRef } from "./attachments";
+import { rewriteAttachmentsForClient, uploadAttachment } from "./attachments";
 import { getUserControlStub, isAdmin } from "./auth";
 import { log } from "./logger";
 import { HttpMcpGatekeeper, type McpGatekeeper, type McpGatekeeperConfig } from "./mcp-gatekeeper";
@@ -296,6 +298,14 @@ export class CodingAgent extends Think<Env, DodoConfig> {
   private mcpDepth = 0;
   /** AbortController for the currently running fiber prompt. Signalled by handleAbort(). */
   private _fiberAbortController: AbortController | null = null;
+  /**
+   * Per-tool-call attachment references captured during streaming. Populated
+   * by the `onToolAttachments` callback threaded into `buildToolsForThink`.
+   * Cleared per chat turn in `runThinkChat` so attachments from one prompt
+   * don't bleed into the next. Used to enrich the streamed `tool_result`
+   * SSE event with images produced by the tool.
+   */
+  private _toolAttachments: Map<string, AttachmentRef[]> = new Map();
   private readonly presence = new PresenceTracker();
   readonly stateBackend;
   private readonly transports = new Map<string, AgentConnectionTransport>();
@@ -411,6 +421,16 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       isAdminUser: isAdmin(ownerEmail ?? null, this.env),
       ownerId: this.resolveOwnerId(ownerEmail),
       ownerEmail,
+      sessionId: this.sessionId(),
+      // Forward tool-produced attachments (e.g. browser_execute screenshots)
+      // to the SSE stream so the chat UI can render them in real time.
+      onToolAttachments: (toolCallId, attachments) => {
+        this._toolAttachments.set(toolCallId, attachments);
+        this.emitEvent({
+          data: { toolCallId, attachments: attachments.map((a) => ({ mediaType: a.mediaType, url: a.url, size: a.size })) },
+          type: "tool_attachments",
+        });
+      },
       stateBackend: this.stateBackend,
       mcpGatekeepers: this.mcpGatekeepers,
     });
@@ -3120,20 +3140,57 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     let fullText = "";
     let streamError: string | null = null;
 
+    // Reset per-turn tool attachment cache. The map is keyed by toolCallId and
+    // populated by the onToolAttachments callback in getTools() — clearing here
+    // ensures attachments from a previous prompt don't leak into this turn's
+    // tool_result events.
+    this._toolAttachments.clear();
+    // Collect assistant-generated images streamed during this turn. Uploaded
+    // to R2 at onDone() once we know the assistant message id.
+    const generatedImages: Array<{ mediaType: string; url: string }> = [];
+
     const callback: StreamCallback = {
       onEvent: (json: string) => {
         try {
           const chunk = JSON.parse(json);
-          // Bridge Think chunk events to Dodo SSE format
+          // Bridge Think chunk events to Dodo SSE format. Chunks come from
+          // the AI SDK's `toUIMessageStream()` pipeline — see the ai package
+          // for the full chunk type union.
           if (chunk.type === "text-delta") {
             const delta = chunk.delta ?? "";
             fullText += delta;
             this.emitEvent({ data: { delta }, type: "text_delta" });
-          } else if (chunk.type === "tool-call") {
+          } else if (chunk.type === "tool-input-available") {
+            // Tool arguments finalised — show the user that a tool is running.
             this.emitEvent({
-              data: { code: chunk.args ?? "", result: chunk.toolCallId },
+              data: {
+                toolCallId: chunk.toolCallId,
+                toolName: chunk.toolName,
+                input: chunk.input,
+              },
               type: "tool_call",
             });
+          } else if (chunk.type === "tool-output-available") {
+            // Tool finished — emit the result plus any images the tool
+            // produced (streamed earlier via the onToolAttachments callback).
+            const refs = this._toolAttachments.get(chunk.toolCallId) ?? [];
+            this.emitEvent({
+              data: {
+                toolCallId: chunk.toolCallId,
+                output: chunk.output,
+                attachments: rewriteAttachmentsForClient(
+                  refs.map((r) => ({ mediaType: r.mediaType, url: r.url, size: r.size })),
+                ),
+              },
+              type: "tool_result",
+            });
+          } else if (chunk.type === "file") {
+            // Assistant generated an image (Gemini, Gemma vision, etc.).
+            // The AI SDK emits a data URL; we defer the R2 upload to onDone()
+            // so we can key it by the assistant message id.
+            if (typeof chunk.mediaType === "string" && typeof chunk.url === "string") {
+              generatedImages.push({ mediaType: chunk.mediaType, url: chunk.url });
+            }
           } else if (chunk.type === "error") {
             // AI SDK emits { type: "error", errorText: "..." } when the gateway
             // returns an error. Think's applyChunkToParts silently drops these.
@@ -3191,6 +3248,37 @@ export class CodingAgent extends Think<Env, DodoConfig> {
         tokenInput,
         tokenOutput,
       });
+    }
+
+    // Persist any assistant-generated images to R2 and emit a message-level
+    // attachments event so the UI can render them. We do this post-stream
+    // because we need the assistant message id (only known after onDone) to
+    // key the R2 object. The inline data URL remains on the UIMessage part;
+    // `uiMessageToChatRecord` handles the transport from data URL → served URL.
+    if (assistantMessageId && generatedImages.length > 0) {
+      const uploaded: AttachmentRef[] = [];
+      for (const img of generatedImages) {
+        const ref = await uploadAttachment(this.env, {
+          sessionId: this.sessionId(),
+          messageId: assistantMessageId,
+          mediaType: img.mediaType,
+          data: img.url, // uploadAttachment strips the data: prefix
+          ownerEmail: options?.authorEmail,
+          source: "assistant",
+        });
+        if (ref) uploaded.push(ref);
+      }
+      if (uploaded.length > 0) {
+        this.emitEvent({
+          data: {
+            messageId: assistantMessageId,
+            attachments: rewriteAttachmentsForClient(
+              uploaded.map((r) => ({ mediaType: r.mediaType, url: r.url, size: r.size })),
+            ),
+          },
+          type: "message_attachments",
+        });
+      }
     }
 
     // Check if context compaction is needed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { log } from "./logger";
 import { createDodoMcpServer } from "./mcp";
 import { createDodoCodeModeMcpServer } from "./mcp-codemode";
 import { MCP_CATALOG } from "./mcp-catalog";
+import { fetchAttachment } from "./attachments";
 import { AllowlistOutbound } from "./outbound";
 import { RateLimiter } from "./rate-limit";
 import { DodoPublicApi } from "./rpc-api";
@@ -1220,6 +1221,24 @@ app.delete("/session/:id/file", async (c) => {
   const denied = requirePermission(c, "write");
   if (denied) return denied;
   return proxyToAgent(c.req.raw, c.env, c.req.param("id"), `/file${new URL(c.req.raw.url).search}`);
+});
+
+// Serve an image attachment (chat screenshot, user upload, generated image).
+// Hono wildcard captures {messageId}/{filename} as the second path segment.
+// ACL is inherited from the /session/:id/* middleware — if the caller can't
+// read the session, they can't read its attachments.
+app.get("/session/:id/attachment/:messageId/:filename", async (c) => {
+  const denied = requirePermission(c, "readonly");
+  if (denied) return denied;
+  const sessionId = c.req.param("id");
+  const messageId = c.req.param("messageId");
+  const filename = c.req.param("filename");
+  if (!sessionId || !messageId || !filename) {
+    return c.json({ error: "Missing path segment" }, 400);
+  }
+  const response = await fetchAttachment(c.env, sessionId, `${messageId}/${filename}`);
+  if (!response) return c.json({ error: "Attachment not found" }, 404);
+  return response;
 });
 
 app.post("/session/:id/search", async (c) => {

--- a/src/think-adapter.ts
+++ b/src/think-adapter.ts
@@ -74,6 +74,7 @@ export interface SnapshotV2 {
 // ─── Adapter functions ───
 
 import type { UIMessage } from "ai";
+import { attachmentUrlToHttpPath, isAttachmentUrl } from "./attachments";
 import type { ChatMessageRecord } from "./types";
 
 /**
@@ -104,17 +105,70 @@ const SAFE_IMAGE_MEDIA_TYPES = new Set([
   "image/webp",
 ]);
 
+/**
+ * Walk a tool result's `output` value looking for image content parts. The
+ * AI SDK's `ToolResultOutput` variant `{type: "content", value: [...]}` can
+ * carry `{type: "image-data", data, mediaType}` or `{type: "media", data,
+ * mediaType}` (deprecated). We accept either.
+ *
+ * browser_execute currently returns text output (see src/browser/tools.ts)
+ * and images flow via the `onToolAttachments` side channel, but this helper
+ * future-proofs for tools that want to use the canonical multipart path.
+ */
+function collectToolOutputImages(
+  output: unknown,
+  attachments: Array<{ mediaType: string; url: string }>,
+): void {
+  if (!output || typeof output !== "object") return;
+  const o = output as { type?: string; value?: unknown };
+  if (o.type !== "content" || !Array.isArray(o.value)) return;
+  for (const part of o.value) {
+    if (!part || typeof part !== "object") continue;
+    const p = part as { type?: string; data?: string; mediaType?: string; url?: string };
+    if (!p.mediaType || !SAFE_IMAGE_MEDIA_TYPES.has(p.mediaType)) continue;
+    // image-data (canonical) or media (deprecated) carry base64 in `data`
+    if ((p.type === "image-data" || p.type === "media") && typeof p.data === "string") {
+      attachments.push({
+        mediaType: p.mediaType,
+        url: `data:${p.mediaType};base64,${p.data}`,
+      });
+      continue;
+    }
+    // file-url carries a URL we can serve through directly
+    if (p.type === "file-url" && typeof p.url === "string") {
+      const url = toClientUrl(p.url, p.mediaType);
+      if (url) attachments.push({ mediaType: p.mediaType, url });
+    }
+  }
+}
+
+/**
+ * Rewrite a stored attachment URL to something the browser can load:
+ *   - `dodo-attachment://…` → `/session/:id/attachment/…` HTTP path
+ *   - `data:image/…;base64,…` → unchanged (inline fallback for dev without R2)
+ *   - Raw base64 → inflated to `data:<mediaType>;base64,…` (legacy messages)
+ */
+function toClientUrl(rawUrl: string, mediaType: string): string | null {
+  if (rawUrl.startsWith("data:")) return rawUrl;
+  if (isAttachmentUrl(rawUrl)) return attachmentUrlToHttpPath(rawUrl);
+  // Treat anything else as raw base64 (legacy path — pre-R2 messages stored
+  // the base64 payload directly in `url` to dodge AI SDK downloadAssets).
+  return `data:${mediaType};base64,${rawUrl}`;
+}
+
 export function uiMessageToChatRecord(
   msg: UIMessage,
   meta: Partial<MessageMetadata> = {},
 ): ChatMessageRecord {
   // Extract text content from parts
   let content = "";
-  // NOTE: attachments carry the full base64 image data (or a data URL) so the
-  // frontend can re-render history without a round-trip to storage. This means
-  // message history grows linearly with image bytes — a known limitation. When
-  // persistent image storage lands (R2 + signed URL references), swap `url`
-  // for the storage URL and stop inlining base64 here.
+  // Attachments can come from three sources on the stored UIMessage:
+  //   1. User/assistant `file` parts (direct uploads, model-generated images)
+  //   2. Tool-result parts that carry image data in their output (screenshots)
+  // In all cases the stored `url` is either a `dodo-attachment://` pointer to
+  // an R2 object or — in legacy messages or local-dev fallbacks — a data URL
+  // or raw base64. `toClientUrl()` normalises all three shapes to something
+  // the browser can load.
   const attachments: Array<{ mediaType: string; url: string }> = [];
   if (msg.parts) {
     content = msg.parts
@@ -122,18 +176,28 @@ export function uiMessageToChatRecord(
       .map((p) => p.text)
       .join("");
     for (const p of msg.parts) {
-      if (p.type !== "file") continue;
-      const mediaType = (p as { mediaType?: string }).mediaType;
-      // Defensive: re-check mediaType here even though the schema gated it on
-      // ingest. Protects against malformed stored messages or future callers
-      // that bypass the HTTP layer.
-      if (!mediaType || !SAFE_IMAGE_MEDIA_TYPES.has(mediaType)) continue;
-      const rawUrl = (p as { url?: string }).url;
-      if (typeof rawUrl !== "string" || rawUrl.length === 0) continue;
-      // Ensure the URL is a data URL for frontend rendering — the stored value
-      // may be raw base64 (for AI SDK compatibility) or already a data URL.
-      const url = rawUrl.startsWith("data:") ? rawUrl : `data:${mediaType};base64,${rawUrl}`;
-      attachments.push({ mediaType, url });
+      // File parts on user/assistant messages
+      if (p.type === "file") {
+        const mediaType = (p as { mediaType?: string }).mediaType;
+        // Defensive: re-check mediaType here even though the schema gated it on
+        // ingest. Protects against malformed stored messages or future callers
+        // that bypass the HTTP layer.
+        if (!mediaType || !SAFE_IMAGE_MEDIA_TYPES.has(mediaType)) continue;
+        const rawUrl = (p as { url?: string }).url;
+        if (typeof rawUrl !== "string" || rawUrl.length === 0) continue;
+        const url = toClientUrl(rawUrl, mediaType);
+        if (!url) continue;
+        attachments.push({ mediaType, url });
+        continue;
+      }
+      // Tool parts — Think encodes these as `type: "tool-<name>"` with an
+      // `output` field when the state is "output-available". If the output
+      // carries image content parts, surface them as attachments so the UI
+      // can render browser screenshots alongside the assistant's narration.
+      const typed = p as { type?: string; output?: unknown };
+      if (typeof typed.type === "string" && typed.type.startsWith("tool-") && typed.output) {
+        collectToolOutputImages(typed.output, attachments);
+      }
     }
   }
 

--- a/test/attachments-unit.test.ts
+++ b/test/attachments-unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachmentUrlToHttpPath,
+  attachmentUrlToKey,
+  attachmentUrlToSessionId,
+  isAttachmentUrl,
+  rewriteAttachmentsForClient,
+} from "../src/attachments";
+
+describe("attachments — URL helpers", () => {
+  const valid = "dodo-attachment://sess-abc/msg-123/file-xyz.png";
+
+  it("recognises dodo-attachment URLs", () => {
+    expect(isAttachmentUrl(valid)).toBe(true);
+    expect(isAttachmentUrl("data:image/png;base64,AAAA")).toBe(false);
+    expect(isAttachmentUrl("https://example.com/a.png")).toBe(false);
+    expect(isAttachmentUrl("")).toBe(false);
+  });
+
+  it("maps a valid URL to an R2 key", () => {
+    expect(attachmentUrlToKey(valid)).toBe("attachments/sess-abc/msg-123/file-xyz.png");
+  });
+
+  it("returns null for malformed URLs", () => {
+    expect(attachmentUrlToKey("dodo-attachment://")).toBeNull();
+    expect(attachmentUrlToKey("dodo-attachment://only-one")).toBeNull();
+    expect(attachmentUrlToKey("dodo-attachment://a/b")).toBeNull();
+    expect(attachmentUrlToKey("dodo-attachment://a/b/c/d")).toBeNull();
+    expect(attachmentUrlToKey("not-a-dodo-url")).toBeNull();
+  });
+
+  it("rejects path traversal attempts", () => {
+    // Any segment containing `..` should be refused — the R2 key prefix is
+    // controlled but we rely on the sessionId to scope access; escaping that
+    // prefix would cross sessions.
+    expect(attachmentUrlToKey("dodo-attachment://../etc/passwd.png")).toBeNull();
+    expect(attachmentUrlToKey("dodo-attachment://sess/../msg/f.png")).toBeNull();
+    expect(attachmentUrlToKey("dodo-attachment://sess/msg/../f.png")).toBeNull();
+  });
+
+  it("extracts the session id for cross-session ACL checks", () => {
+    expect(attachmentUrlToSessionId(valid)).toBe("sess-abc");
+    expect(attachmentUrlToSessionId("data:image/png;base64,AAA")).toBeNull();
+  });
+
+  it("builds HTTP path for client consumption", () => {
+    expect(attachmentUrlToHttpPath(valid)).toBe(
+      "/session/sess-abc/attachment/msg-123/file-xyz.png",
+    );
+  });
+
+  it("returns null HTTP path for non-attachment URLs", () => {
+    expect(attachmentUrlToHttpPath("data:image/png;base64,AAA")).toBeNull();
+    expect(attachmentUrlToHttpPath("https://cdn.example/img.png")).toBeNull();
+  });
+});
+
+describe("attachments — rewriteAttachmentsForClient", () => {
+  it("rewrites dodo-attachment URLs to HTTP paths", () => {
+    const input = [
+      { mediaType: "image/png", url: "dodo-attachment://s/m/a.png" },
+      { mediaType: "image/jpeg", url: "dodo-attachment://s/m/b.jpg" },
+    ];
+    const out = rewriteAttachmentsForClient(input);
+    expect(out).toEqual([
+      { mediaType: "image/png", url: "/session/s/attachment/m/a.png" },
+      { mediaType: "image/jpeg", url: "/session/s/attachment/m/b.jpg" },
+    ]);
+  });
+
+  it("leaves data URLs and external URLs untouched", () => {
+    const input = [
+      { mediaType: "image/png", url: "data:image/png;base64,AAAA" },
+      { mediaType: "image/png", url: "https://cdn.example/img.png" },
+    ];
+    const out = rewriteAttachmentsForClient(input);
+    expect(out).toEqual(input);
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(rewriteAttachmentsForClient(undefined)).toBeUndefined();
+  });
+
+  it("preserves extra fields on attachment objects", () => {
+    const input = [
+      { mediaType: "image/png", url: "dodo-attachment://s/m/a.png", size: 1234 },
+    ];
+    const out = rewriteAttachmentsForClient(input);
+    expect(out).toEqual([
+      { mediaType: "image/png", url: "/session/s/attachment/m/a.png", size: 1234 },
+    ]);
+  });
+});

--- a/test/browser-screenshots-unit.test.ts
+++ b/test/browser-screenshots-unit.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { extractScreenshots } from "../src/browser/tools";
+
+// Tiny 1×1 PNG — enough bytes (base64 > 100) for extractScreenshots to
+// consider it a real screenshot rather than a random short string.
+const TINY_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+describe("extractScreenshots", () => {
+  it("pulls a screenshot out of the raw CDP Page.captureScreenshot shape", () => {
+    const input = { data: TINY_PNG, format: "png" };
+    const { images, scrubbed } = extractScreenshots(input);
+    expect(images).toHaveLength(1);
+    expect(images[0].mediaType).toBe("image/png");
+    expect(images[0].data).toBe(TINY_PNG);
+    // `data` has been stripped, `format` preserved, placeholder marker added
+    expect(scrubbed).toEqual({ format: "png", _attachmentPlaceholder: true });
+  });
+
+  it("handles the docstring shape { screenshot, format }", () => {
+    const input = { screenshot: TINY_PNG, format: "jpeg", encoding: "base64" };
+    const { images, scrubbed } = extractScreenshots(input);
+    expect(images).toHaveLength(1);
+    expect(images[0].mediaType).toBe("image/jpeg");
+    expect(scrubbed).toEqual({ format: "jpeg", encoding: "base64", _attachmentPlaceholder: true });
+  });
+
+  it("recurses into nested objects", () => {
+    const input = {
+      result: { data: TINY_PNG, format: "webp" },
+      meta: { navigated: true },
+    };
+    const { images, scrubbed } = extractScreenshots(input);
+    expect(images).toHaveLength(1);
+    expect(images[0].mediaType).toBe("image/webp");
+    expect(scrubbed).toEqual({
+      result: { format: "webp", _attachmentPlaceholder: true },
+      meta: { navigated: true },
+    });
+  });
+
+  it("recurses into arrays", () => {
+    const input = [
+      { data: TINY_PNG, format: "png" },
+      { data: TINY_PNG, format: "jpeg" },
+    ];
+    const { images } = extractScreenshots(input);
+    expect(images).toHaveLength(2);
+    expect(images[0].mediaType).toBe("image/png");
+    expect(images[1].mediaType).toBe("image/jpeg");
+  });
+
+  it("ignores objects without a known format", () => {
+    const input = { data: TINY_PNG, format: "tiff" };
+    const { images, scrubbed } = extractScreenshots(input);
+    expect(images).toHaveLength(0);
+    expect(scrubbed).toEqual(input);
+  });
+
+  it("ignores data strings below the size heuristic", () => {
+    // A short string that happens to have data+format shape but is too short
+    // to be a real screenshot — probably not an image. Stay well below the
+    // 50-char threshold used internally.
+    const input = { data: "short", format: "png" };
+    const { images } = extractScreenshots(input);
+    expect(images).toHaveLength(0);
+  });
+
+  it("leaves non-screenshot values untouched", () => {
+    const input = { title: "Example", url: "https://example.com", loaded: true };
+    const { images, scrubbed } = extractScreenshots(input);
+    expect(images).toHaveLength(0);
+    expect(scrubbed).toEqual(input);
+  });
+
+  it("passes primitives through unchanged", () => {
+    expect(extractScreenshots("hello").scrubbed).toBe("hello");
+    expect(extractScreenshots(42).scrubbed).toBe(42);
+    expect(extractScreenshots(null).scrubbed).toBe(null);
+  });
+});

--- a/test/multimodal-unit.test.ts
+++ b/test/multimodal-unit.test.ts
@@ -141,4 +141,84 @@ describe("uiMessageToChatRecord — multimodal", () => {
     const record = uiMessageToChatRecord(msg);
     expect(record.attachments).toBeUndefined();
   });
+
+  it("rewrites dodo-attachment URLs on file parts to session-scoped HTTP paths", () => {
+    const msg: UIMessage = {
+      id: "msg-r2",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Here's the image" },
+        {
+          type: "file",
+          mediaType: "image/png",
+          url: "dodo-attachment://sess-xyz/msg-r2/pic.png",
+        } as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toHaveLength(1);
+    expect(record.attachments![0].url).toBe(
+      "/session/sess-xyz/attachment/msg-r2/pic.png",
+    );
+  });
+
+  it("extracts images from assistant tool-result content parts", () => {
+    // Simulate the canonical multipart tool-output shape from the AI SDK.
+    // Tool parts on a stored UIMessage have `type: "tool-<name>"` with an
+    // `output` field when `state: "output-available"`.
+    const msg: UIMessage = {
+      id: "msg-tool",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Here's what the page looks like:" },
+        {
+          type: "tool-browser_execute",
+          toolCallId: "call-1",
+          toolName: "browser_execute",
+          state: "output-available",
+          output: {
+            type: "content",
+            value: [
+              { type: "text", text: "Navigated to example.com" },
+              { type: "image-data", data: "AAAA", mediaType: "image/png" },
+            ],
+          },
+        } as unknown as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toHaveLength(1);
+    expect(record.attachments![0].mediaType).toBe("image/png");
+    expect(record.attachments![0].url).toBe("data:image/png;base64,AAAA");
+  });
+
+  it("rewrites dodo-attachment file-url parts inside tool output", () => {
+    const msg: UIMessage = {
+      id: "msg-tool2",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-browser_execute",
+          toolCallId: "call-2",
+          toolName: "browser_execute",
+          state: "output-available",
+          output: {
+            type: "content",
+            value: [
+              {
+                type: "file-url",
+                url: "dodo-attachment://sess-t/toolcall-call-2/a.png",
+                mediaType: "image/png",
+              },
+            ],
+          },
+        } as unknown as UIMessage["parts"][number],
+      ],
+    };
+    const record = uiMessageToChatRecord(msg);
+    expect(record.attachments).toHaveLength(1);
+    expect(record.attachments![0].url).toBe(
+      "/session/sess-t/attachment/toolcall-call-2/a.png",
+    );
+  });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,6 +34,11 @@
     }
   ],
   "r2_buckets": [
+    // Chat attachments (screenshots, uploaded images, model-generated images)
+    // are stored in this bucket under the `attachments/` prefix. Run
+    // `scripts/setup-attachment-lifecycle.sh` once per account to provision
+    // the 30-day auto-expiry rule — lifecycle rules aren't yet configurable
+    // from wrangler.jsonc, so they live out-of-band.
     { "binding": "WORKSPACE_BUCKET", "bucket_name": "dodo-workspaces" }
   ],
   "browser": {


### PR DESCRIPTION
## Summary

Images now flow end-to-end through a unified R2-backed pipeline for three sources:

- **Browser tool screenshots** (`Page.captureScreenshot` via `browser_execute`)
- **Model-generated images** (Gemini imagen, Gemma vision, etc.)
- **User uploads** (existing feature, now uses the same storage path)

Previously `browser_execute` returned screenshots as base64 inside its JSON result — which burned context tokens and never reached the chat UI. Model-generated images were dropped entirely by the SSE bridge.

## Four layers

### Layer 1 — Tool extraction (`src/browser/tools.ts`)
`extractScreenshots` walks CDP results, detecting `{data, format}` and `{screenshot, format}` shapes. Extracted images are uploaded to R2 before tool output returns. The model gets a compact summary instead of 100KB+ of base64 per image.

### Layer 2 — Streaming (`src/coding-agent.ts`)
Fix dead code: the `tool-call` handler was listening for a chunk type that Think's `toUIMessageStream()` never emits. Replaced with four SSE events: `tool_call`, `tool_result`, `tool_attachments` (early), `message_attachments` (late).

### Layer 3 — Storage (`src/attachments.ts`, `scripts/setup-attachment-lifecycle.sh`)
- `dodo-attachment://{sessionId}/{messageId}/{attachmentId}.{ext}` URL scheme for stored refs
- `GET /session/:id/attachment/:messageId/:filename` serves R2 objects, ACL inherited from the existing `/session/:id/*` middleware
- Traversal guards on URL parsing
- **30-day auto-expiry** via R2 lifecycle rule — run `scripts/setup-attachment-lifecycle.sh` once per account (lifecycle rules aren't yet configurable via wrangler.jsonc)

### Layer 4 — Frontend (`public/js/dodo-chat.js`, `src/think-adapter.ts`)
- Assistant bubbles now render attachments (previously only user bubbles)
- `renderToolCall` + `updateToolCallResult` build a tool bubble at call start and enrich with output + images at completion
- `attachImagesToMessage` handles late-arriving generated images by data-msg-id
- `uiMessageToChatRecord` walks assistant tool-result content parts for restored history
- `toClientUrl` normalises three storage shapes: dodo-attachment://, data URLs, raw base64 (legacy)

## Tests

- `test/attachments-unit.test.ts` (11 tests) — URL parsing, traversal guards, client URL rewriting
- `test/browser-screenshots-unit.test.ts` (8 tests) — both CDP shapes, recursion, size heuristic
- `test/multimodal-unit.test.ts` (+2 tests) — dodo-attachment rewrite for file parts and tool-result content parts

**Full suite: 350 passing, 2 skipped.**

## Follow-ups (intentionally out of scope)

- MCP-provided image tools that return images via canonical multipart output will work via `uiMessageToChatRecord` restoration but won't yet benefit from the early `tool_attachments` event — would need a similar extractor in the agentic.ts MCP adapter.
- WebSocket prompt path still doesn't accept user-uploaded images (pre-existing from PR #4).