### PR TITLE
fix: rewrite dodo-attachment URLs on tool_attachments SSE event

### DIFF
--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -429,7 +429,12 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       onToolAttachments: (toolCallId, attachments) => {
         this._toolAttachments.set(toolCallId, attachments);
         this.emitEvent({
-          data: { toolCallId, attachments: attachments.map((a) => ({ mediaType: a.mediaType, url: a.url, size: a.size })) },
+          data: {
+            toolCallId,
+            attachments: rewriteAttachmentsForClient(
+              attachments.map((a) => ({ mediaType: a.mediaType, url: a.url, size: a.size })),
+            ),
+          },
           type: "tool_attachments",
         });
       },


### PR DESCRIPTION
Smoke-testing PR #19 in production revealed that the `tool_attachments` event (fired early, as soon as a tool uploads images) was emitting raw `dodo-attachment://` URLs instead of the session-scoped HTTP path the browser can load.

Result: the first image bubble on a tool call rendered as a broken `<img>` with a non-resolvable custom scheme; the second (from `tool_result`) rendered correctly because that code path already ran through `rewriteAttachmentsForClient`.

One-line fix — same rewrite applied on both emission sites. Existing `rewriteAttachmentsForClient` tests already cover the rewrite logic; the bug was purely 'forgot to call it in one of the two places'.