### PR TITLE
feat: document desktop viewport + full-page capture in browser_execute

### DIFF
--- a/src/browser/tools.ts
+++ b/src/browser/tools.ts
@@ -83,9 +83,44 @@ declare const cdp: {
 
 Write an async arrow function in JavaScript. Do NOT use TypeScript syntax.
 
+The default viewport is 800×600. For most user-visible work (reviewing a
+page, capturing a UI bug, etc.) you should override this to a desktop
+resolution before navigating — otherwise screenshots look cramped and
+mobile-styled. Set deviceScaleFactor:2 for crisp images on HiDPI displays.
+
 Common patterns:
-// Navigate and screenshot
+// Desktop screenshot (recommended default for most tasks)
 async () => {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440, height: 900, deviceScaleFactor: 2, mobile: false
+  });
+  await cdp.send("Page.enable");
+  await cdp.send("Page.navigate", { url: "https://example.com" });
+  await new Promise(r => setTimeout(r, 3000));
+  const { data } = await cdp.send("Page.captureScreenshot", { format: "png" });
+  return { screenshot: data, format: "png", encoding: "base64" };
+}
+
+// Full-page screenshot (captures the entire scrollable page, not just the viewport)
+async () => {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440, height: 900, deviceScaleFactor: 2, mobile: false
+  });
+  await cdp.send("Page.enable");
+  await cdp.send("Page.navigate", { url: "https://example.com" });
+  await new Promise(r => setTimeout(r, 3000));
+  const { data } = await cdp.send("Page.captureScreenshot", {
+    format: "png",
+    captureBeyondViewport: true
+  });
+  return { screenshot: data, format: "png", encoding: "base64" };
+}
+
+// Mobile screenshot (only when the user specifically asks for a mobile view)
+async () => {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: 390, height: 844, deviceScaleFactor: 3, mobile: true
+  });
   await cdp.send("Page.enable");
   await cdp.send("Page.navigate", { url: "https://example.com" });
   await new Promise(r => setTimeout(r, 3000));


### PR DESCRIPTION
Screenshots were landing at 800×600 because the docstring example didn't set a viewport and models copy the example verbatim. Fine for scraping, cramped and mobile-styled when a human wants to review the output.

Teaches the model about `Emulation.setDeviceMetricsOverride` with three new example patterns:

| Pattern | Dimensions | Use |
|---|---|---|
| **Desktop** (new default) | 1440×900 @2x DPR | Most user-visible tasks |
| **Full-page** | 1440×900 @2x DPR + `captureBeyondViewport: true` | Reviewing long pages/articles |
| **Mobile** | 390×844 @3x DPR, `mobile: true` | Only when user asks for mobile |

No code changes — just the docstring. Existing calls that don't set a viewport still work at 800×600.

Tested locally (31 tests still pass). Will verify in prod after merge.