### PR TITLE
Fix dispatch prompt header: dynamic baseBranch + skip-npm hint (#24, #25)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -500,10 +500,11 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
 
       const content = [
         `Repository is already cloned at ${repo.dir}.`,
-        `You are on the main branch. Push to remote branch '${branch}' when done.`,
+        `You are on the ${baseBranch} branch. Push to remote branch '${branch}' when done.`,
         `Do not clone again. Do not change branch names.`,
         `Use commit message: ${commitMessage}`,
         `Push with git_push_checked and ref set to '${branch}'.`,
+        `Skip npm/node verification commands (npm run typecheck, npm test, npm install) — the sandbox cannot run them. The dispatching system will verify externally.`,
         prompt,
       ].join("\n\n");
 


### PR DESCRIPTION
## Summary

Auto-generated by Dodo worker run `c8701bca-fcc0-4f5b-8891-e535c0992f79`.

fix(mcp): dynamic baseBranch in dispatch prompt + skip-npm hint

Closes #24 and #25.

- Replace hardcoded 'You are on the main branch' with the actual
  baseBranch value so stacked-PR dispatches aren't misled.
- Add an explicit 'Skip npm/node verification commands' line so
  the worker doesn't waste 50-100k tokens hunting for child_process.

## Metadata

- Branch: `fix/dispatch-prompt-header`
- Base: `main`
- Session: `e7e84495-5a4b-4b32-9d39-968eef6a1af3`
- Strategy: `agent`
- Verification: `{"aheadBy":1,"baseRef":"main","branch":"fix/dispatch-prompt-header","changedFiles":["src/mcp.ts"],"compareUrl":"https://api.github.com/repos/jonnyparris/dodo/compare/main...fix%2Fdispatch-prompt-header","ok":true,"provider":"github","remoteUrl":"https://github.com/jonnyparris/dodo"}`

---

🤖 Drafted via `dodo_dispatch_repo_prompt`.