### PR TITLE
fix: gateway-aware model routing + Workers AI Kimi K2.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
   <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/jonnyparris/dodo">
     <img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare"/>
   </a>
+  &nbsp;
+  <a href="https://dash.cloudflare.com/4b430e167a301330d13a9bb42f3986a2/workers/services/view/dodo/production/builds">
+    <img src="https://img.shields.io/github/check-runs/jonnyparris/dodo/main?nameFilter=Workers+Builds%3A+dodo&label=workers%20build&logo=cloudflare&logoColor=white" alt="Workers Build status"/>
+  </a>
 </p>
 
 ---

--- a/public/index.html
+++ b/public/index.html
@@ -533,7 +533,7 @@
             <input id="cfg-model" list="model-list" style="margin-bottom:6px"/>
             <datalist id="model-list"></datalist>
             <label style="font-size:11px;color:var(--muted)">Gateway</label>
-            <select id="cfg-gateway" style="margin-bottom:6px">
+            <select id="cfg-gateway" style="margin-bottom:6px" onchange="loadModels()">
               <option value="ai-gateway">AI Gateway</option>
               <option value="opencode">OpenCode</option>
             </select>

--- a/public/js/dodo-settings.js
+++ b/public/js/dodo-settings.js
@@ -117,7 +117,14 @@ function showUpdateBanner(commit){
 }
 async function loadModels(){
   try{
-    const{models}=await api("/api/models");
+    // Filter server-side by the currently selected gateway so the picker never
+    // offers a model that would fail on first prompt. Falls back to the saved
+    // config's gateway when the UI selector isn't rendered yet.
+    const gwSel=$("cfg-gateway");
+    let gw=gwSel?gwSel.value:null;
+    if(!gw){try{const cfg=await api("/api/config");gw=cfg&&cfg.activeGateway;}catch{}}
+    const qs=gw?`?gateway=${encodeURIComponent(gw)}`:"";
+    const{models}=await api(`/api/models${qs}`);
     const dl=$("model-list");dl.innerHTML="";
     models.forEach(m=>{const o=document.createElement("option");o.value=m.id;o.textContent=`${m.name}${m.costInput?` ($${m.costInput}/M in)`:''}`; dl.appendChild(o)});
   }catch{}

--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -162,6 +162,24 @@ function trimBaseUrl(url: string): string {
   return url.endsWith("/") ? url.slice(0, -1) : url;
 }
 
+/** Some model IDs need rewriting before they're sent to the upstream gateway.
+ *  - Workers AI models (`@cf/…`) need the `workers-ai/` prefix per AI Gateway
+ *    unified-API docs: https://developers.cloudflare.com/ai-gateway/chat-completion/
+ *    They only work when the active gateway is `ai-gateway`.
+ *  Returns the wire-format model ID, or throws if the combination is invalid. */
+export function resolveWireModelId(modelId: string, activeGateway: "opencode" | "ai-gateway"): string {
+  if (modelId.startsWith("@cf/")) {
+    if (activeGateway !== "ai-gateway") {
+      throw new Error(
+        `Workers AI model "${modelId}" requires the AI Gateway. ` +
+        `Switch gateway to "ai-gateway" in Settings (or via update_config).`,
+      );
+    }
+    return `workers-ai/${modelId}`;
+  }
+  return modelId;
+}
+
 export function buildProvider(config: AppConfig, env: Env) {
   const isOpencode = config.activeGateway === "opencode";
   const baseURL = isOpencode
@@ -170,13 +188,38 @@ export function buildProvider(config: AppConfig, env: Env) {
 
   const headers: Record<string, string> = isOpencode
     ? { "cf-access-token": env.OPENCODE_GATEWAY_TOKEN ?? "" }
-    : { "x-api-key": env.AI_GATEWAY_KEY ?? "" };
+    : {
+        // AI Gateway unified API: auth with `cf-aig-authorization` bearer.
+        // We keep `x-api-key` for back-compat with existing deployments.
+        "cf-aig-authorization": `Bearer ${env.AI_GATEWAY_KEY ?? ""}`,
+        "x-api-key": env.AI_GATEWAY_KEY ?? "",
+      };
 
-  return createOpenAICompatible({
+  const provider = createOpenAICompatible({
     baseURL,
     headers,
     includeUsage: true,
     name: config.activeGateway,
+  });
+
+  // Wrap `chatModel` / `languageModel` / the callable provider so callers can pass
+  // the user-facing id (e.g. `@cf/moonshotai/kimi-k2.6`) and we translate it to the
+  // wire format (`workers-ai/@cf/moonshotai/kimi-k2.6`) exactly once, at the edge.
+  const translate = (modelId: string) => resolveWireModelId(modelId, config.activeGateway);
+  const originalChatModel = provider.chatModel.bind(provider);
+  const originalLanguageModel = provider.languageModel.bind(provider);
+
+  return new Proxy(provider, {
+    // Intercept `provider("model-id")` (the callable form).
+    apply(_target, _thisArg, args: [string, ...unknown[]]) {
+      const [modelId, ...rest] = args;
+      return originalLanguageModel(translate(modelId), ...(rest as []));
+    },
+    get(target, prop, receiver) {
+      if (prop === "chatModel") return (modelId: string) => originalChatModel(translate(modelId));
+      if (prop === "languageModel") return (modelId: string, cfg?: unknown) => originalLanguageModel(translate(modelId), cfg as Parameters<typeof originalLanguageModel>[1]);
+      return Reflect.get(target, prop, receiver);
+    },
   });
 }
 

--- a/src/shared-index.ts
+++ b/src/shared-index.ts
@@ -24,12 +24,43 @@ const FALLBACK_MODELS = [
   { id: "deepseek/deepseek-reasoner", name: "DeepSeek Reasoner", provider: "DeepSeek", costInput: 0.55, costOutput: 2.19, contextWindow: 128_000 },
 ];
 
-/** Workers AI models available via AI Gateway's OpenAI-compatible endpoint. */
+/** Workers AI models available via AI Gateway's unified OpenAI-compatible endpoint.
+ *  Routed with the `workers-ai/` prefix per https://developers.cloudflare.com/ai-gateway/chat-completion/
+ *  These only work when `activeGateway === "ai-gateway"`. */
 const WORKERS_AI_MODELS = [
+  { id: "@cf/moonshotai/kimi-k2.6", name: "Kimi K2.6 (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 262_144 },
   { id: "@cf/google/gemma-4-26b-a4b-it", name: "Gemma 4 26B A4B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 256_000 },
   { id: "@cf/meta/llama-4-scout-17b-16e-instruct", name: "Llama 4 Scout 17B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 131_072 },
   { id: "@cf/qwen/qwen2.5-coder-32b-instruct", name: "Qwen 2.5 Coder 32B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 32_768 },
 ];
+
+/** Provider prefixes the opencode gateway can actually route.
+ *  The models.dev provider TOMLs often fall back to `anthropic/` for non-Anthropic models
+ *  (kimi, glm, qwen, mimo, minimax, etc.), which the gateway then forwards to Anthropic
+ *  and Anthropic rejects with 404. We filter those out server-side so the UI never shows
+ *  a model that will fail on first prompt. Use Workers AI (ai-gateway) instead. */
+const OPENCODE_SUPPORTED_PROVIDER_PREFIXES = new Set(["openai", "anthropic", "google", "deepseek"]);
+
+/** Slug prefixes (after the provider/) that are known to NOT be real Anthropic models.
+ *  These slugs slip through as `anthropic/…` because models.dev defaults to `anthropic` when
+ *  the TOML has no `[provider].npm`. The gateway forwards to Anthropic and 404s. */
+const OPENCODE_BAD_SLUG_PREFIXES = [
+  "kimi", "glm", "qwen", "qwen3", "mimo", "minimax", "nemotron", "trinity", "grok-code", "big-pickle",
+];
+
+function isRoutableByOpencodeGateway(id: string): boolean {
+  const slashIdx = id.indexOf("/");
+  if (slashIdx === -1) return false;
+  const providerPrefix = id.slice(0, slashIdx);
+  const slug = id.slice(slashIdx + 1);
+  if (id.startsWith("@cf/")) return false; // Workers AI — ai-gateway only
+  if (!OPENCODE_SUPPORTED_PROVIDER_PREFIXES.has(providerPrefix)) return false;
+  if (providerPrefix === "anthropic") {
+    // Filter models falsely labelled `anthropic/...` because of the models.dev fallback
+    return !OPENCODE_BAD_SLUG_PREFIXES.some((bad) => slug.startsWith(bad));
+  }
+  return true;
+}
 
 /**
  * SharedIndex DO — global singleton (`idFromName("global")`).
@@ -146,10 +177,21 @@ export class SharedIndex extends DurableObject<Env> {
         if (refresh) {
           this.db.exec("DELETE FROM models_cache");
         }
+        // `gateway` query param filters the list for the active gateway.
+        // "opencode" → only providers the opencode gateway can actually route.
+        // "ai-gateway" → upstream unified API models + Workers AI @cf/ models.
+        // (omitted) → unfiltered (legacy callers).
+        const gateway = url.searchParams.get("gateway");
         const models = await this.getModels();
-        const ids = new Set(models.map((m) => m.id));
-        const extras = WORKERS_AI_MODELS.filter((m) => !ids.has(m.id));
-        return Response.json({ models: [...models, ...extras] });
+        const filteredBase = gateway === "opencode"
+          ? models.filter((m) => isRoutableByOpencodeGateway(m.id))
+          : models;
+        const ids = new Set(filteredBase.map((m) => m.id));
+        // Workers AI models only appear when ai-gateway is the target (or no filter).
+        const extras = gateway === "opencode"
+          ? []
+          : WORKERS_AI_MODELS.filter((m) => !ids.has(m.id));
+        return Response.json({ models: [...filteredBase, ...extras] });
       }
 
       // ─── Session shares ───

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type { UserControl } from "./user-control";
 
 export interface Env {
   AI_GATEWAY_BASE_URL: string;
+  AI_GATEWAY_DEFAULT_MODEL?: string;
   AI_GATEWAY_KEY?: string;
   ALLOW_UNAUTHENTICATED_DEV?: string;
   ASSETS?: Fetcher;

--- a/src/user-control.ts
+++ b/src/user-control.ts
@@ -777,7 +777,22 @@ export class UserControl extends DurableObject<Env> {
   }
 
   private updateConfig(input: UpdateConfigRequest): AppConfig {
-    const nextConfig = { ...this.readConfig(), ...input };
+    const current = this.readConfig();
+    const nextConfig = { ...current, ...input };
+
+    // Auto-swap model when the user changes gateway and the current model
+    // isn't routable by the new gateway. Prevents the "Bad Request on first prompt"
+    // failure mode reported in jonnyparris/dodo#30.
+    const gatewayChanged = input.activeGateway && input.activeGateway !== current.activeGateway;
+    const modelExplicit = Object.prototype.hasOwnProperty.call(input, "model");
+    if (gatewayChanged && !modelExplicit) {
+      if (input.activeGateway === "ai-gateway" && !nextConfig.model.startsWith("@cf/")) {
+        nextConfig.model = this.env.AI_GATEWAY_DEFAULT_MODEL ?? "@cf/moonshotai/kimi-k2.6";
+      } else if (input.activeGateway === "opencode" && nextConfig.model.startsWith("@cf/")) {
+        nextConfig.model = this.env.DEFAULT_MODEL;
+      }
+    }
+
     const now = nowEpoch();
     for (const [key, value] of Object.entries(nextConfig)) {
       this.db.exec(

--- a/test/model-routing-unit.test.ts
+++ b/test/model-routing-unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure unit tests for gateway model routing.
+ *
+ * Covers:
+ * - `resolveWireModelId`: translates user-facing model IDs (`@cf/…`) into the
+ *   wire format that Cloudflare's AI Gateway unified API expects
+ *   (`workers-ai/@cf/…`), and rejects Workers AI models on the opencode gateway.
+ * - The `isRoutableByOpencodeGateway` helper used to filter `/api/models`
+ *   responses so the UI never offers a model that will fail on first prompt.
+ *
+ * The second helper lives inside src/shared-index.ts and isn't exported; it's
+ * re-implemented here to match (same pattern as permission-unit.test.ts).
+ * Keep this file in sync with the canonical versions in src/.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveWireModelId } from "../src/agentic";
+
+// ─── Mirror of isRoutableByOpencodeGateway from src/shared-index.ts ───
+
+const OPENCODE_SUPPORTED_PROVIDER_PREFIXES = new Set(["openai", "anthropic", "google", "deepseek"]);
+const OPENCODE_BAD_SLUG_PREFIXES = [
+  "kimi", "glm", "qwen", "qwen3", "mimo", "minimax", "nemotron", "trinity", "grok-code", "big-pickle",
+];
+
+function isRoutableByOpencodeGateway(id: string): boolean {
+  const slashIdx = id.indexOf("/");
+  if (slashIdx === -1) return false;
+  const providerPrefix = id.slice(0, slashIdx);
+  const slug = id.slice(slashIdx + 1);
+  if (id.startsWith("@cf/")) return false;
+  if (!OPENCODE_SUPPORTED_PROVIDER_PREFIXES.has(providerPrefix)) return false;
+  if (providerPrefix === "anthropic") {
+    return !OPENCODE_BAD_SLUG_PREFIXES.some((bad) => slug.startsWith(bad));
+  }
+  return true;
+}
+
+// ─── Tests ───
+
+describe("resolveWireModelId", () => {
+  it("prefixes @cf/ models with workers-ai/ on the ai-gateway", () => {
+    expect(resolveWireModelId("@cf/moonshotai/kimi-k2.6", "ai-gateway")).toBe(
+      "workers-ai/@cf/moonshotai/kimi-k2.6",
+    );
+    expect(resolveWireModelId("@cf/meta/llama-4-scout-17b-16e-instruct", "ai-gateway")).toBe(
+      "workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct",
+    );
+  });
+
+  it("passes non-@cf/ models through unchanged on both gateways", () => {
+    expect(resolveWireModelId("openai/gpt-5.4", "ai-gateway")).toBe("openai/gpt-5.4");
+    expect(resolveWireModelId("openai/gpt-5.4", "opencode")).toBe("openai/gpt-5.4");
+    expect(resolveWireModelId("anthropic/claude-sonnet-4-6", "opencode")).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("throws when a @cf/ model is used with the opencode gateway", () => {
+    expect(() => resolveWireModelId("@cf/moonshotai/kimi-k2.6", "opencode")).toThrow(
+      /requires the AI Gateway/,
+    );
+  });
+});
+
+describe("isRoutableByOpencodeGateway", () => {
+  it("accepts real Anthropic, OpenAI, Google, DeepSeek models", () => {
+    expect(isRoutableByOpencodeGateway("anthropic/claude-sonnet-4-6")).toBe(true);
+    expect(isRoutableByOpencodeGateway("anthropic/claude-opus-4-7")).toBe(true);
+    expect(isRoutableByOpencodeGateway("openai/gpt-5.4")).toBe(true);
+    expect(isRoutableByOpencodeGateway("google/gemini-3-pro")).toBe(true);
+    expect(isRoutableByOpencodeGateway("deepseek/deepseek-chat")).toBe(true);
+  });
+
+  it("rejects models falsely prefixed with anthropic/ by the models.dev fallback", () => {
+    // These are the ones the original issue #30 reported as Bad Request.
+    expect(isRoutableByOpencodeGateway("anthropic/kimi-k2.6")).toBe(false);
+    expect(isRoutableByOpencodeGateway("anthropic/kimi-k2-thinking")).toBe(false);
+    expect(isRoutableByOpencodeGateway("anthropic/glm-4.6")).toBe(false);
+    expect(isRoutableByOpencodeGateway("anthropic/qwen3-coder")).toBe(false);
+    expect(isRoutableByOpencodeGateway("anthropic/mimo-v2-flash-free")).toBe(false);
+    expect(isRoutableByOpencodeGateway("anthropic/minimax-m2.7")).toBe(false);
+    expect(isRoutableByOpencodeGateway("anthropic/grok-code")).toBe(false);
+  });
+
+  it("rejects Workers AI @cf/ models (ai-gateway only)", () => {
+    expect(isRoutableByOpencodeGateway("@cf/moonshotai/kimi-k2.6")).toBe(false);
+    expect(isRoutableByOpencodeGateway("@cf/meta/llama-4-scout-17b-16e-instruct")).toBe(false);
+  });
+
+  it("rejects unknown provider prefixes", () => {
+    expect(isRoutableByOpencodeGateway("alibaba/qwen3.5-plus")).toBe(false);
+    expect(isRoutableByOpencodeGateway("moonshotai/kimi-k2.6")).toBe(false);
+    expect(isRoutableByOpencodeGateway("openrouter/kimi-k2.6")).toBe(false);
+  });
+
+  it("rejects malformed IDs without a provider prefix", () => {
+    expect(isRoutableByOpencodeGateway("kimi-k2.6")).toBe(false);
+    expect(isRoutableByOpencodeGateway("")).toBe(false);
+  });
+});

--- a/test/user-control.test.ts
+++ b/test/user-control.test.ts
@@ -76,6 +76,60 @@ describe("UserControl DO", () => {
     });
   });
 
+  it("config: switching gateway to ai-gateway auto-swaps to a Workers AI model when none is specified", async () => {
+    // Start from opencode + opencode-routable model.
+    await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "opencode", model: "openai/gpt-5.4" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+
+    // Flip gateway only — no model override. Server should pick a @cf/ default.
+    const flipRes = await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "ai-gateway" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+    expect(flipRes.status).toBe(200);
+    const flipped = (await flipRes.json()) as { activeGateway: string; model: string };
+    expect(flipped.activeGateway).toBe("ai-gateway");
+    expect(flipped.model.startsWith("@cf/")).toBe(true);
+
+    // Flip back — model should revert to opencode-routable default.
+    const revertRes = await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "opencode" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+    const reverted = (await revertRes.json()) as { activeGateway: string; model: string };
+    expect(reverted.activeGateway).toBe("opencode");
+    expect(reverted.model.startsWith("@cf/")).toBe(false);
+
+    // Restore defaults
+    await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "opencode", model: "claude-test" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+  });
+
+  it("config: passing both activeGateway and model respects the explicit model", async () => {
+    const res = await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "ai-gateway", model: "openai/gpt-5.4" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+    const cfg = (await res.json()) as { model: string };
+    expect(cfg.model).toBe("openai/gpt-5.4");
+
+    // Restore
+    await fetchJson("/api/config", {
+      body: JSON.stringify({ activeGateway: "opencode", model: "claude-test" }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+  });
+
   // ─── Memory ───
 
   it("memory: create → search → read → update → delete", async () => {

--- a/wrangler.dev.jsonc
+++ b/wrangler.dev.jsonc
@@ -54,8 +54,11 @@
     "CF_ACCESS_TEAM_DOMAIN": "https://your-team.cloudflareaccess.com",
     // Set this to any model your LLM gateway supports
     "DEFAULT_MODEL": "anthropic/claude-sonnet-4",
+    // Default model used when a new session is created with activeGateway=ai-gateway.
+    "AI_GATEWAY_DEFAULT_MODEL": "@cf/moonshotai/kimi-k2.6",
     "OPENCODE_BASE_URL": "https://opencode.cloudflare.dev/compat",
-    "AI_GATEWAY_BASE_URL": "https://gateway.ai.cloudflare.com/v1",
+    // AI Gateway unified API: include /{account_id}/{gateway_id}/compat
+    "AI_GATEWAY_BASE_URL": "https://gateway.ai.cloudflare.com/v1/your-account-id/your-gateway/compat",
     "DODO_VERSION": "0.4.0-dev",
     "ADMIN_EMAIL": "you@example.com"
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,8 +68,13 @@
   },
   "vars": {
     "DEFAULT_MODEL": "anthropic/claude-sonnet-4",
+    // Default model used when a new session is created with activeGateway=ai-gateway.
+    // Workers AI models (`@cf/…`) are only routable via AI Gateway.
+    "AI_GATEWAY_DEFAULT_MODEL": "@cf/moonshotai/kimi-k2.6",
     "OPENCODE_BASE_URL": "https://opencode.cloudflare.dev/compat",
-    "AI_GATEWAY_BASE_URL": "https://gateway.ai.cloudflare.com/v1",
+    // AI Gateway unified API base URL — include /{account_id}/{gateway_id}/compat
+    // so the OpenAI-compatible SDK hits /chat/completions correctly.
+    "AI_GATEWAY_BASE_URL": "https://gateway.ai.cloudflare.com/v1/4b430e167a301330d13a9bb42f3986a2/jp-gw/compat",
     "DODO_VERSION": "0.4.0"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #30. The \`/api/models\` endpoint was serving Kimi/GLM/Qwen/MiMo/MiniMax entries silently mis-prefixed \`anthropic/…\` by the models.dev fallback. The opencode gateway forwarded them to Anthropic, which 404'd every prompt (\`model: kimi-k2.6\`).

## Changes

- **Filter \`/api/models\` by gateway.** New \`?gateway=opencode|ai-gateway\` query param. Opencode only returns truly-routable provider prefixes (openai/anthropic/google/deepseek) and excludes slug prefixes Anthropic doesn't serve (kimi, glm, qwen, mimo, minimax, nemotron, trinity, grok-code). The settings UI passes the current gateway and reloads the datalist when it changes.

- **Workers AI via AI Gateway unified API.** \`buildProvider()\` translates user-facing \`@cf/…\` IDs into the wire format \`workers-ai/@cf/…\` per [the docs](https://developers.cloudflare.com/ai-gateway/chat-completion/), and rejects them on the opencode gateway with a clear error pointing to Settings. Adds \`cf-aig-authorization\` header alongside the legacy \`x-api-key\`.

- **Added \`@cf/moonshotai/kimi-k2.6\`** to \`WORKERS_AI_MODELS\` with its real 262k context window.

- **New \`AI_GATEWAY_DEFAULT_MODEL\` env var** defaults to \`@cf/moonshotai/kimi-k2.6\`. When the user flips gateway without specifying a model, \`updateConfig\` auto-swaps to a routable default for the new gateway — prevents Bad-Request-on-first-prompt.

- **Point \`AI_GATEWAY_BASE_URL\` at jp-gw** with the full \`/{account_id}/{gateway}/compat\` path. The previous \`…/v1\` was missing the account+gateway segments and couldn't have worked.

## Tests

- 30 files / 365 passed (+2 new user-control tests covering auto-model-swap, +1 new \`model-routing-unit.test.ts\` with 8 tests covering \`resolveWireModelId\` and \`isRoutableByOpencodeGateway\`).
- \`tsc --noEmit\` clean.

## Verification plan after merge

1. \`dodo_update_config({ activeGateway: "ai-gateway", model: "@cf/moonshotai/kimi-k2.6" })\`
2. \`dodo_send_message\` — expect a real Kimi response (not \`Bad Request\`).
3. Flip back to \`activeGateway: "opencode"\` without passing model — config should revert to \`DEFAULT_MODEL\`.
4. \`GET /api/models?gateway=opencode\` — expect no \`anthropic/kimi-*\` entries.

beep-boop-🤖