### PR TITLE
fix(mcp): support non-main baseBranch in dispatch (stacked PRs)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -404,9 +404,12 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     });
 
     try {
-      // Clone fresh (avoids fork binary corruption issues)
+      // Clone fresh (avoids fork binary corruption issues). Deeper clone when
+      // stacking on a non-default base so later `git log` calls see the stack.
+      const isStacked = baseBranch !== repo.defaultBranch;
+      const cloneDepth = isStacked ? 20 : 1;
       await agentJson(env, worker.id, "/git/clone", {
-        body: JSON.stringify({ branch: baseBranch, dir: repo.dir, url: repo.url }),
+        body: JSON.stringify({ branch: baseBranch, depth: cloneDepth, dir: repo.dir, url: repo.url }),
         headers: { "content-type": "application/json" },
         method: "POST",
       }, depth);
@@ -488,9 +491,13 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     });
 
     try {
-      // Clone fresh
+      // Clone fresh. When stacking on a non-default base branch, fetch more
+      // history so the LLM can `git log` the existing stack without needing
+      // to pull or fetch (both of which fail under singleBranch+shallow).
+      const isStacked = baseBranch !== repo.defaultBranch;
+      const cloneDepth = isStacked ? 20 : 1;
       await agentJson(env, worker.id, "/git/clone", {
-        body: JSON.stringify({ branch: baseBranch, dir: repo.dir, url: repo.url }),
+        body: JSON.stringify({ branch: baseBranch, depth: cloneDepth, dir: repo.dir, url: repo.url }),
         headers: { "content-type": "application/json" },
         method: "POST",
       }, depth);
@@ -502,6 +509,7 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
         `Repository is already cloned at ${repo.dir}.`,
         `You are on the ${baseBranch} branch. Push to remote branch '${branch}' when done.`,
         `Do not clone again. Do not change branch names.`,
+        `Do NOT run git_pull or git_fetch — the clone is singleBranch+shallow. The repository is already on the correct branch.`,
         `Use commit message: ${commitMessage}`,
         `Push with git_push_checked and ref set to '${branch}'.`,
         `Skip npm/node verification commands (npm run typecheck, npm test, npm install) — the sandbox cannot run them. The dispatching system will verify externally.`,


### PR DESCRIPTION
## Summary

Fixes #11. When stacking a dispatch on a non-default base branch, the clone would succeed but any LLM-issued `git pull` / `git fetch` against sibling refs failed with "branch not found" — because the clone is `singleBranch: true, depth: 1`.

## Changes

- Bump clone depth to 20 when `baseBranch !== repo.defaultBranch`, so `git log` inside the sandbox shows the stack's previous commits.
- Add explicit instruction to the dispatch prompt: **do not** run `git_pull` or `git_fetch`. The clone already put us on the right branch.
- Applied to both strategies: agent (`dispatch_repo_prompt`) and deterministic (`run_repo_edits`).

## Why this is enough

- `github-pr.ts:createDraftPrForRun` already targets `run.baseBranch` for the PR base.
- `git.ts:verifyRemoteBranch` uses the GitHub REST compare API, which works for any ref without needing local fetch.

So the end-to-end stacked flow (clone → edit → commit → push → verify → draft PR) already works for any base ref — we just needed to stop the LLM from trying to pull on a shallow clone.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 365 tests pass (no dispatch tests exist yet; scope creep to add a full harness)
- [ ] Dogfood: dispatch Phase N+1 of a stacked migration with `baseBranch` set to the previous phase branch — should no longer halt mid-task

Closes #11.

🤖 Generated with OpenCode.