### PR TITLE
feat(mcp): external typecheck+test gate via GitHub Actions

### DIFF
--- a/.github/workflows/dodo-verify.yml
+++ b/.github/workflows/dodo-verify.yml
@@ -1,0 +1,36 @@
+name: dodo-verify
+
+# External typecheck + test gate for dispatches. The Dodo MCP dispatches this
+# workflow via workflow_dispatch after a successful branch push, then polls
+# for completion before opening a draft PR. See src/github-actions.ts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref the dispatcher wants verified (informational — the workflow runs on the dispatched ref by default)
+        required: false
+        type: string
+  # Also run on push so humans get the same signal in their PRs.
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test

--- a/.github/workflows/dodo-verify.yml
+++ b/.github/workflows/dodo-verify.yml
@@ -11,9 +11,10 @@ on:
         description: Ref the dispatcher wants verified (informational — the workflow runs on the dispatched ref by default)
         required: false
         type: string
-  # Also run on push so humans get the same signal in their PRs.
-  push:
-    branches-ignore:
+  # Run on PRs so human-authored branches get the same typecheck/test signal
+  # without double-running on every push.
+  pull_request:
+    branches:
       - main
 
 jobs:

--- a/src/github-actions.ts
+++ b/src/github-actions.ts
@@ -54,9 +54,18 @@ async function resolveGithubToken(env: Env, ownerEmail?: string): Promise<string
  * and poll for completion.
  *
  * `workflow_dispatch` is asynchronous — GitHub responds 204 before the run
- * exists. We then query the runs list (filtered by branch + event) to find
- * the one we just triggered. We pick the most recent run created within the
- * last 2 minutes to avoid confusing ourselves with older runs.
+ * exists. We then query the runs list to find the one we just triggered.
+ *
+ * Run identification uses two signals to avoid grabbing an unrelated run
+ * (e.g. a concurrent human-dispatched run for the same branch):
+ *
+ *   1. **head_sha match** (primary). Before dispatching, we look up the
+ *      branch's current tip. A `workflow_dispatch` run records that sha as
+ *      `head_sha`, so a match is authoritative.
+ *   2. **created_at window** (secondary). Fallback when the branch sha
+ *      lookup fails. Tight 2-second window accepts real NTP skew while
+ *      rejecting runs from humans dispatching the same workflow moments
+ *      earlier.
  */
 export async function triggerVerifyWorkflow(input: {
   env: Env;
@@ -69,6 +78,9 @@ export async function triggerVerifyWorkflow(input: {
   if (!parsed) return null;
   const token = await resolveGithubToken(env, ownerEmail);
   if (!token) return null;
+
+  // Resolve the branch's current head sha so we can match runs authoritatively.
+  const expectedHeadSha = await fetchBranchHeadSha({ owner: parsed.owner, repo: parsed.repo, branch: run.branch, token });
 
   const triggerUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/actions/workflows/${encodeURIComponent(run.verifyWorkflow)}/dispatches`;
   const triggeredAt = Date.now();
@@ -91,11 +103,16 @@ export async function triggerVerifyWorkflow(input: {
     const listUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/actions/workflows/${encodeURIComponent(run.verifyWorkflow)}/runs?branch=${encodeURIComponent(run.branch)}&event=workflow_dispatch&per_page=5`;
     const listRes = await fetch(listUrl, { headers: ghHeaders(token) });
     if (!listRes.ok) continue;
-    const listData = (await listRes.json()) as { workflow_runs: Array<{ id: number; html_url: string; created_at: string }> };
+    const listData = (await listRes.json()) as { workflow_runs: Array<{ id: number; html_url: string; created_at: string; head_sha?: string }> };
     const candidate = listData.workflow_runs?.find((r) => {
+      // Primary: head_sha match is authoritative if we have the expected sha.
+      if (expectedHeadSha && r.head_sha === expectedHeadSha) return true;
+      if (expectedHeadSha) return false; // have sha, must match — don't fall through to time window
+
+      // Fallback: tight time window. ±2s covers NTP skew; tighter than the
+      // typical human reaction time between dispatches.
       const createdMs = Date.parse(r.created_at);
-      // Only accept runs created after we triggered (minus 10s clock skew).
-      return Number.isFinite(createdMs) && createdMs >= triggeredAt - 10_000;
+      return Number.isFinite(createdMs) && createdMs >= triggeredAt - 2_000;
     });
     if (candidate) {
       return { runId: String(candidate.id), htmlUrl: candidate.html_url };
@@ -104,6 +121,27 @@ export async function triggerVerifyWorkflow(input: {
 
   console.warn("[verify-gate] workflow dispatched but run id not found within 5s");
   return null;
+}
+
+/**
+ * Look up the current head sha for a branch. Returns null on any failure so
+ * the caller can fall back to time-window matching.
+ */
+async function fetchBranchHeadSha(input: {
+  owner: string;
+  repo: string;
+  branch: string;
+  token: string;
+}): Promise<string | null> {
+  try {
+    const url = `https://api.github.com/repos/${input.owner}/${input.repo}/branches/${encodeURIComponent(input.branch)}`;
+    const res = await fetch(url, { headers: ghHeaders(input.token) });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { commit?: { sha?: string } };
+    return data.commit?.sha ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/github-actions.ts
+++ b/src/github-actions.ts
@@ -1,0 +1,157 @@
+import type { Env, WorkerRunRecord } from "./types";
+import { parseGithubRepo } from "./github-pr";
+import { getUserControlStub } from "./auth";
+
+/**
+ * GitHub Actions verify gate.
+ *
+ * Triggers a `workflow_dispatch` on the repo's verify workflow for the pushed
+ * branch, then polls the workflow run until it reaches a terminal conclusion.
+ *
+ * This is our external typecheck/test gate — the Workers sandbox can't run
+ * `npm install`/`tsc`/`vitest`, so we delegate verification to GitHub Actions
+ * on every dispatched PR.
+ */
+
+export interface VerifyTriggerResult {
+  runId: string;
+  htmlUrl: string;
+}
+
+export interface VerifyPollResult {
+  conclusion: "success" | "failure" | "cancelled" | "timed_out" | "action_required" | "neutral" | "skipped" | "stale" | "startup_failure";
+  htmlUrl: string;
+  /** ISO timestamp of when the workflow run finished. */
+  completedAt: string | null;
+}
+
+/**
+ * Resolve a GitHub token. Prefers per-user encrypted secret (`github_token`),
+ * falls back to env.GITHUB_TOKEN. Mirrors the resolution in github-pr.ts.
+ */
+async function resolveGithubToken(env: Env, ownerEmail?: string): Promise<string | undefined> {
+  if (ownerEmail) {
+    try {
+      const stub = getUserControlStub(env, ownerEmail);
+      const response = await stub.fetch("https://user-control/internal/secret/github_token", {
+        headers: { "x-owner-email": ownerEmail },
+      });
+      if (response.ok) {
+        const { value } = (await response.json()) as { value: string };
+        if (value) return value;
+      }
+    } catch {
+      // Fall through to env
+    }
+  }
+  return env.GITHUB_TOKEN;
+}
+
+/**
+ * Trigger the verify workflow for a branch via `workflow_dispatch`.
+ *
+ * Returns the newly-created workflow run so the caller can persist the id
+ * and poll for completion.
+ *
+ * `workflow_dispatch` is asynchronous — GitHub responds 204 before the run
+ * exists. We then query the runs list (filtered by branch + event) to find
+ * the one we just triggered. We pick the most recent run created within the
+ * last 2 minutes to avoid confusing ourselves with older runs.
+ */
+export async function triggerVerifyWorkflow(input: {
+  env: Env;
+  run: WorkerRunRecord;
+  ownerEmail?: string;
+}): Promise<VerifyTriggerResult | null> {
+  const { env, run, ownerEmail } = input;
+  if (!run.verifyWorkflow) return null;
+  const parsed = parseGithubRepo(run.repoUrl);
+  if (!parsed) return null;
+  const token = await resolveGithubToken(env, ownerEmail);
+  if (!token) return null;
+
+  const triggerUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/actions/workflows/${encodeURIComponent(run.verifyWorkflow)}/dispatches`;
+  const triggeredAt = Date.now();
+  const triggerRes = await fetch(triggerUrl, {
+    method: "POST",
+    headers: ghHeaders(token),
+    body: JSON.stringify({ ref: run.branch }),
+  });
+
+  if (!triggerRes.ok) {
+    const errorText = await triggerRes.text();
+    console.warn(`[verify-gate] workflow_dispatch failed ${triggerRes.status}:`, errorText.slice(0, 500));
+    return null;
+  }
+
+  // Find the run we just created. GitHub's API can take a second or two to
+  // materialize the run — poll the runs list briefly.
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await sleep(500 + attempt * 500);
+    const listUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/actions/workflows/${encodeURIComponent(run.verifyWorkflow)}/runs?branch=${encodeURIComponent(run.branch)}&event=workflow_dispatch&per_page=5`;
+    const listRes = await fetch(listUrl, { headers: ghHeaders(token) });
+    if (!listRes.ok) continue;
+    const listData = (await listRes.json()) as { workflow_runs: Array<{ id: number; html_url: string; created_at: string }> };
+    const candidate = listData.workflow_runs?.find((r) => {
+      const createdMs = Date.parse(r.created_at);
+      // Only accept runs created after we triggered (minus 10s clock skew).
+      return Number.isFinite(createdMs) && createdMs >= triggeredAt - 10_000;
+    });
+    if (candidate) {
+      return { runId: String(candidate.id), htmlUrl: candidate.html_url };
+    }
+  }
+
+  console.warn("[verify-gate] workflow dispatched but run id not found within 5s");
+  return null;
+}
+
+/**
+ * Fetch the current status of a workflow run. Returns a poll result only if
+ * the run has reached a terminal state; returns null while still running.
+ */
+export async function pollVerifyWorkflow(input: {
+  env: Env;
+  run: WorkerRunRecord;
+  ownerEmail?: string;
+}): Promise<VerifyPollResult | null> {
+  const { env, run, ownerEmail } = input;
+  if (!run.verifyWorkflowRunId) return null;
+  const parsed = parseGithubRepo(run.repoUrl);
+  if (!parsed) return null;
+  const token = await resolveGithubToken(env, ownerEmail);
+  if (!token) return null;
+
+  const url = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/actions/runs/${encodeURIComponent(run.verifyWorkflowRunId)}`;
+  const res = await fetch(url, { headers: ghHeaders(token) });
+  if (!res.ok) {
+    console.warn(`[verify-gate] poll failed ${res.status}`);
+    return null;
+  }
+
+  const data = (await res.json()) as {
+    status: string;
+    conclusion: string | null;
+    html_url: string;
+    updated_at: string;
+  };
+
+  // status is one of: queued, in_progress, completed
+  if (data.status !== "completed") return null;
+  const conclusion = (data.conclusion ?? "failure") as VerifyPollResult["conclusion"];
+  return { conclusion, htmlUrl: data.html_url, completedAt: data.updated_at };
+}
+
+function ghHeaders(token: string): Record<string, string> {
+  return {
+    "Accept": "application/vnd.github+json",
+    "Authorization": `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "dodo-dispatch",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -3,6 +3,7 @@ import { getAgentByName } from "agents";
 import { z } from "zod";
 import { getSharedIndexStub, getUserControlStub, resolveAdminEmail } from "./auth";
 import { createDraftPrForRun } from "./github-pr";
+import { pollVerifyWorkflow, triggerVerifyWorkflow } from "./github-actions";
 import { getKnownRepo, listKnownRepos } from "./repos";
 import type { CodingAgent } from "./coding-agent";
 import type { Env, WorkerRunRecord } from "./types";
@@ -103,6 +104,7 @@ async function createWorkerRun(env: Env, input: {
   status: string;
   strategy: "deterministic" | "agent";
   title: string;
+  verifyWorkflow?: string | null;
 }) {
   return userJson<{ id: string } & Record<string, unknown>>(env, "/worker-runs", {
     body: JSON.stringify(input),
@@ -111,7 +113,15 @@ async function createWorkerRun(env: Env, input: {
   });
 }
 
-async function updateWorkerRun(env: Env, runId: string, patch: { status?: string; lastError?: string | null; failureSnapshotId?: string | null; verification?: Record<string, unknown> | null; prUrl?: string | null }): Promise<WorkerRunRecord> {
+async function updateWorkerRun(env: Env, runId: string, patch: {
+  status?: string;
+  lastError?: string | null;
+  failureSnapshotId?: string | null;
+  verification?: Record<string, unknown> | null;
+  prUrl?: string | null;
+  verifyWorkflowRunId?: string | null;
+  verifyWorkflowHtmlUrl?: string | null;
+}): Promise<WorkerRunRecord> {
   return userJson<WorkerRunRecord>(env, `/worker-runs/${encodeURIComponent(runId)}`, {
     body: JSON.stringify(patch),
     headers: { "content-type": "application/json" },
@@ -186,6 +196,61 @@ async function prepareRepoBranch(env: Env, sessionId: string, repoDir: string, b
     headers: { "content-type": "application/json" },
     method: "POST",
   }, depth);
+}
+
+/**
+ * After a run reaches `done` (or we explicitly decide to open a PR without
+ * blocking on verify), attempt to open a draft PR. PR failures are non-fatal
+ * so they don't regress the run.
+ */
+async function finalizePr(env: Env, run: WorkerRunRecord, ownerEmail: string | undefined, verification: Record<string, unknown>): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const prUrl = await createDraftPrForRun(env, run, ownerEmail);
+  if (prUrl) {
+    const withPr = await updateWorkerRun(env, run.id, { prUrl });
+    return textResult({ run: withPr, verification });
+  }
+  return textResult({ run, verification });
+}
+
+/**
+ * Poll the verify-gate workflow run for a worker run that's currently
+ * `checks_running`. If the workflow is still in flight, return a running
+ * response. On success: transition `checks_passed` → auto-PR → `done`. On
+ * failure: capture the workflow URL in a failure snapshot and mark `failed`.
+ */
+async function pollAndFinalize(env: Env, run: WorkerRunRecord, ownerEmail: string | undefined): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: true }> {
+  const pollResult = await pollVerifyWorkflow({ env, run, ownerEmail });
+  if (!pollResult) {
+    return textResult({ run, status: "checks_running", verifyWorkflowHtmlUrl: run.verifyWorkflowHtmlUrl });
+  }
+  const verification = (run.verification ?? {}) as Record<string, unknown>;
+  if (pollResult.conclusion === "success") {
+    const passed = await updateWorkerRun(env, run.id, {
+      status: "checks_passed",
+      verification: { ...verification, verifyGate: { conclusion: "success", htmlUrl: pollResult.htmlUrl, completedAt: pollResult.completedAt } },
+    });
+    // Immediately transition to `done` so the caller sees a single terminal
+    // state, and open the draft PR.
+    const done = await updateWorkerRun(env, run.id, { status: "done" });
+    return await finalizePr(env, done, ownerEmail, passed.verification ?? {});
+  }
+
+  // Non-success conclusion — record a failure snapshot pointing at the run.
+  const failure = await createFailureSnapshot(env, run.id, {
+    reason: "verify_gate_failed",
+    conclusion: pollResult.conclusion,
+    htmlUrl: pollResult.htmlUrl,
+    completedAt: pollResult.completedAt,
+    verifyWorkflow: run.verifyWorkflow,
+  });
+  const message = `Verify workflow concluded '${pollResult.conclusion}' — see ${pollResult.htmlUrl}`;
+  const updated = await updateWorkerRun(env, run.id, {
+    status: "failed",
+    lastError: message,
+    failureSnapshotId: String(failure.id),
+    verification: { ...verification, verifyGate: { conclusion: pollResult.conclusion, htmlUrl: pollResult.htmlUrl, completedAt: pollResult.completedAt } },
+  });
+  return errorResult({ error: message, failureSnapshotId: failure.id, run: updated, verifyWorkflowHtmlUrl: pollResult.htmlUrl });
 }
 
 function textResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
@@ -404,9 +469,12 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     });
 
     try {
-      // Clone fresh (avoids fork binary corruption issues)
+      // Clone fresh (avoids fork binary corruption issues). Deeper clone when
+      // stacking on a non-default base so later `git log` calls see the stack.
+      const isStacked = baseBranch !== repo.defaultBranch;
+      const cloneDepth = isStacked ? 20 : 1;
       await agentJson(env, worker.id, "/git/clone", {
-        body: JSON.stringify({ branch: baseBranch, dir: repo.dir, url: repo.url }),
+        body: JSON.stringify({ branch: baseBranch, depth: cloneDepth, dir: repo.dir, url: repo.url }),
         headers: { "content-type": "application/json" },
         method: "POST",
       }, depth);
@@ -469,7 +537,8 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     commitMessage: z.string().min(1).describe("Commit message the worker should use"),
     expectedFiles: z.array(z.string()).default([]).describe("Files expected to change on the branch"),
     prompt: z.string().min(1).describe("Worker prompt. The repo is already cloned and the branch is already checked out."),
-  }, async ({ repoId, title, branch, baseBranch, commitMessage, expectedFiles, prompt }) => {
+    verifyWorkflow: z.string().min(1).nullable().optional().describe("GitHub Actions workflow filename (e.g. 'dodo-verify.yml') to run as an external typecheck/test gate after the branch pushes. The workflow must accept a `workflow_dispatch` trigger and a `ref` input. Leave null/unset to skip the verify gate (default). See .github/workflows/dodo-verify.yml.example for a template."),
+  }, async ({ repoId, title, branch, baseBranch, commitMessage, expectedFiles, prompt, verifyWorkflow }) => {
     const repo = getKnownRepo(repoId);
     const worker = await createSessionWithTitle(env, title);
     const run = await createWorkerRun(env, {
@@ -485,12 +554,17 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
       status: "session_created",
       strategy: "agent",
       title,
+      verifyWorkflow: verifyWorkflow ?? null,
     });
 
     try {
-      // Clone fresh
+      // Clone fresh. When stacking on a non-default base branch, fetch more
+      // history so the LLM can `git log` the existing stack without needing
+      // to pull or fetch (both of which fail under singleBranch+shallow).
+      const isStacked = baseBranch !== repo.defaultBranch;
+      const cloneDepth = isStacked ? 20 : 1;
       await agentJson(env, worker.id, "/git/clone", {
-        body: JSON.stringify({ branch: baseBranch, dir: repo.dir, url: repo.url }),
+        body: JSON.stringify({ branch: baseBranch, depth: cloneDepth, dir: repo.dir, url: repo.url }),
         headers: { "content-type": "application/json" },
         method: "POST",
       }, depth);
@@ -502,6 +576,7 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
         `Repository is already cloned at ${repo.dir}.`,
         `You are on the ${baseBranch} branch. Push to remote branch '${branch}' when done.`,
         `Do not clone again. Do not change branch names.`,
+        `Do NOT run git_pull or git_fetch — the clone is singleBranch+shallow. The repository is already on the correct branch.`,
         `Use commit message: ${commitMessage}`,
         `Push with git_push_checked and ref set to '${branch}'.`,
         `Skip npm/node verification commands (npm run typecheck, npm test, npm install) — the sandbox cannot run them. The dispatching system will verify externally.`,
@@ -523,25 +598,30 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     }
   });
 
-  server.tool("verify_worker_run", "Verify a tracked worker run. For prompt-based runs, waits for prompt completion and then verifies the remote branch before marking it done.", {
+  server.tool("verify_worker_run", "Verify a tracked worker run. For prompt-based runs, waits for prompt completion, verifies the remote branch, optionally runs a GitHub Actions verify workflow (typecheck/tests), then opens a draft PR and marks the run done.", {
     runId: z.string().min(1).describe("Worker run id"),
   }, async ({ runId }) => {
-    const run = await userJson<{
-      baseBranch: string;
-      branch: string;
-      expectedFiles: string[];
-      id: string;
-      repoDir: string;
-      sessionId: string;
-      status: string;
-      strategy: "deterministic" | "agent";
-    }>(env, `/worker-runs/${encodeURIComponent(runId)}`);
+    const run = await userJson<WorkerRunRecord>(env, `/worker-runs/${encodeURIComponent(runId)}`);
 
     if (run.strategy === "deterministic" && run.status === "done") {
       return textResult(run);
     }
 
+    const ownerEmail = mcpUserEmail(env);
+
     try {
+      // Resume a verify-gate poll if we're mid-check on a prior call.
+      if (run.status === "checks_running" && run.verifyWorkflowRunId) {
+        return await pollAndFinalize(env, run, ownerEmail);
+      }
+
+      // Don't re-trigger the verify gate if we already passed and an auto-PR
+      // attempt simply didn't land a URL. Let the caller retry that path
+      // separately if they want.
+      if (run.status === "checks_passed") {
+        return textResult({ run, note: "checks already passed; call again to retry PR creation" });
+      }
+
       const prompts = await agentJson<{ prompts: Array<{ error: string | null; status: string }> }>(env, run.sessionId, "/prompts", undefined, depth);
       const active = prompts.prompts[0];
       if (!active || active.status === "queued" || active.status === "running") {
@@ -559,17 +639,37 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
         headers: { "content-type": "application/json" },
         method: "POST",
       }, depth);
-      const updated = await updateWorkerRun(env, runId, { status: "done", verification });
 
-      // Auto-open draft PR. Non-fatal — failures don't regress the run.
-      const ownerEmail = mcpUserEmail(env);
-      const prUrl = await createDraftPrForRun(env, updated, ownerEmail);
-      if (prUrl) {
-        const withPr = await updateWorkerRun(env, runId, { prUrl });
-        return textResult({ run: withPr, verification });
+      // Verify gate (optional, opt-in). If the caller set verifyWorkflow on
+      // dispatch, trigger GitHub Actions here and return `checks_running` —
+      // the caller should call verify_worker_run again to poll.
+      if (run.verifyWorkflow) {
+        const triggered = await triggerVerifyWorkflow({ env, run, ownerEmail });
+        if (!triggered) {
+          // Couldn't trigger — don't gate the run on an infrastructure failure.
+          // Log a non-fatal note in the verification record and proceed to PR.
+          const afterVerify = await updateWorkerRun(env, runId, {
+            status: "done",
+            verification: { ...verification, verifyGate: { triggered: false, reason: "workflow_dispatch failed or missing token" } },
+          });
+          return await finalizePr(env, afterVerify, ownerEmail, verification);
+        }
+        const afterTrigger = await updateWorkerRun(env, runId, {
+          status: "checks_running",
+          verification,
+          verifyWorkflowRunId: triggered.runId,
+          verifyWorkflowHtmlUrl: triggered.htmlUrl,
+        });
+        return textResult({
+          run: afterTrigger,
+          status: "checks_running",
+          verifyWorkflowHtmlUrl: triggered.htmlUrl,
+        });
       }
 
-      return textResult({ run: updated, verification });
+      // No verify gate — mark done and open PR (existing behavior).
+      const updated = await updateWorkerRun(env, runId, { status: "done", verification });
+      return await finalizePr(env, updated, ownerEmail, verification);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const failure = await captureFailureSnapshot(env, runId, run.sessionId, run.repoDir, depth);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -199,11 +199,28 @@ async function prepareRepoBranch(env: Env, sessionId: string, repoDir: string, b
 }
 
 /**
+ * Hard cap for the verify gate. If a GitHub Actions run stays in
+ * `queued`/`in_progress` for longer than this (e.g. runner outage, org
+ * concurrency cap, billing issue) we mark the worker run as failed rather
+ * than polling indefinitely. The dodo-verify workflow itself has a
+ * timeout-minutes of 15; we double that to absorb transient queue delays.
+ */
+const VERIFY_GATE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
  * After a run reaches `done` (or we explicitly decide to open a PR without
  * blocking on verify), attempt to open a draft PR. PR failures are non-fatal
  * so they don't regress the run.
+ *
+ * If a prior call already opened a PR (e.g. the caller is double-polling
+ * `verify_worker_run` and both see a terminal state), skip the second
+ * attempt — `createDraftPrForRun` has no existing-PR check and would
+ * otherwise open duplicates.
  */
 async function finalizePr(env: Env, run: WorkerRunRecord, ownerEmail: string | undefined, verification: Record<string, unknown>): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  if (run.prUrl) {
+    return textResult({ run, verification });
+  }
   const prUrl = await createDraftPrForRun(env, run, ownerEmail);
   if (prUrl) {
     const withPr = await updateWorkerRun(env, run.id, { prUrl });
@@ -212,22 +229,54 @@ async function finalizePr(env: Env, run: WorkerRunRecord, ownerEmail: string | u
   return textResult({ run, verification });
 }
 
+/** Read the startedAt ISO string from the verifyGate record. Null if missing. */
+function getVerifyGateStartedAt(run: WorkerRunRecord): number | null {
+  const gate = (run.verification as Record<string, unknown> | null)?.verifyGate as Record<string, unknown> | undefined;
+  const raw = gate?.startedAt;
+  if (typeof raw !== "string") return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
 /**
  * Poll the verify-gate workflow run for a worker run that's currently
  * `checks_running`. If the workflow is still in flight, return a running
  * response. On success: transition `checks_passed` → auto-PR → `done`. On
- * failure: capture the workflow URL in a failure snapshot and mark `failed`.
+ * failure (or timeout): capture the workflow URL in a failure snapshot and
+ * mark `failed`.
  */
 async function pollAndFinalize(env: Env, run: WorkerRunRecord, ownerEmail: string | undefined): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: true }> {
+  const verification = (run.verification ?? {}) as Record<string, unknown>;
   const pollResult = await pollVerifyWorkflow({ env, run, ownerEmail });
+
   if (!pollResult) {
+    // Still running — but check the timeout cap first so we don't poll forever.
+    const startedAt = getVerifyGateStartedAt(run);
+    if (startedAt !== null && Date.now() - startedAt > VERIFY_GATE_TIMEOUT_MS) {
+      const htmlUrl = run.verifyWorkflowHtmlUrl ?? null;
+      const message = `Verify workflow timed out after ${Math.round(VERIFY_GATE_TIMEOUT_MS / 60000)} minutes${htmlUrl ? ` — see ${htmlUrl}` : ""}`;
+      const failure = await createFailureSnapshot(env, run.id, {
+        reason: "verify_gate_timeout",
+        htmlUrl,
+        startedAt: new Date(startedAt).toISOString(),
+        timeoutMs: VERIFY_GATE_TIMEOUT_MS,
+        verifyWorkflow: run.verifyWorkflow,
+      });
+      const updated = await updateWorkerRun(env, run.id, {
+        status: "failed",
+        lastError: message,
+        failureSnapshotId: String(failure.id),
+        verification: { ...verification, verifyGate: { ...(verification.verifyGate as Record<string, unknown> | undefined), conclusion: "timed_out", htmlUrl, timedOutAt: new Date().toISOString() } },
+      });
+      return errorResult({ error: message, failureSnapshotId: failure.id, run: updated, verifyWorkflowHtmlUrl: htmlUrl });
+    }
     return textResult({ run, status: "checks_running", verifyWorkflowHtmlUrl: run.verifyWorkflowHtmlUrl });
   }
-  const verification = (run.verification ?? {}) as Record<string, unknown>;
+
   if (pollResult.conclusion === "success") {
     const passed = await updateWorkerRun(env, run.id, {
       status: "checks_passed",
-      verification: { ...verification, verifyGate: { conclusion: "success", htmlUrl: pollResult.htmlUrl, completedAt: pollResult.completedAt } },
+      verification: { ...verification, verifyGate: { ...(verification.verifyGate as Record<string, unknown> | undefined), conclusion: "success", htmlUrl: pollResult.htmlUrl, completedAt: pollResult.completedAt } },
     });
     // Immediately transition to `done` so the caller sees a single terminal
     // state, and open the draft PR.
@@ -248,7 +297,7 @@ async function pollAndFinalize(env: Env, run: WorkerRunRecord, ownerEmail: strin
     status: "failed",
     lastError: message,
     failureSnapshotId: String(failure.id),
-    verification: { ...verification, verifyGate: { conclusion: pollResult.conclusion, htmlUrl: pollResult.htmlUrl, completedAt: pollResult.completedAt } },
+    verification: { ...verification, verifyGate: { ...(verification.verifyGate as Record<string, unknown> | undefined), conclusion: pollResult.conclusion, htmlUrl: pollResult.htmlUrl, completedAt: pollResult.completedAt } },
   });
   return errorResult({ error: message, failureSnapshotId: failure.id, run: updated, verifyWorkflowHtmlUrl: pollResult.htmlUrl });
 }
@@ -656,7 +705,15 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
         }
         const afterTrigger = await updateWorkerRun(env, runId, {
           status: "checks_running",
-          verification,
+          verification: {
+            ...verification,
+            verifyGate: {
+              startedAt: new Date().toISOString(),
+              workflow: run.verifyWorkflow,
+              runId: triggered.runId,
+              htmlUrl: triggered.htmlUrl,
+            },
+          },
           verifyWorkflowRunId: triggered.runId,
           verifyWorkflowHtmlUrl: triggered.htmlUrl,
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,8 @@ export type WorkerRunStatus =
   | "commit_created"
   | "prompt_running"
   | "push_verified"
+  | "checks_running"
+  | "checks_passed"
   | "done"
   | "failed";
 
@@ -155,6 +157,12 @@ export interface WorkerRunRecord {
   title: string;
   updatedAt: string;
   verification: Record<string, unknown> | null;
+  /** GitHub Actions workflow filename for external verification (e.g. "dodo-verify.yml"). Null = skip verify gate. */
+  verifyWorkflow?: string | null;
+  /** GitHub Actions workflow run id once triggered. */
+  verifyWorkflowRunId?: string | null;
+  /** Public URL of the workflow run for humans to inspect. */
+  verifyWorkflowHtmlUrl?: string | null;
 }
 
 export interface FailureSnapshotRecord {

--- a/src/user-control.ts
+++ b/src/user-control.ts
@@ -57,6 +57,20 @@ const mcpConfigUpdateSchema = z
   })
   .strict();
 
+const workerRunStatusEnum = z.enum([
+  "session_created",
+  "repo_ready",
+  "branch_created",
+  "edit_applied",
+  "commit_created",
+  "prompt_running",
+  "push_verified",
+  "checks_running",
+  "checks_passed",
+  "done",
+  "failed",
+]);
+
 const workerRunCreateSchema = z.object({
   sessionId: z.string().min(1),
   parentSessionId: z.string().min(1).nullable().optional(),
@@ -69,15 +83,18 @@ const workerRunCreateSchema = z.object({
   title: z.string().min(1),
   commitMessage: z.string().min(1).nullable().optional(),
   expectedFiles: z.array(z.string()).default([]),
-  status: z.enum(["session_created", "repo_ready", "branch_created", "edit_applied", "commit_created", "prompt_running", "push_verified", "done", "failed"]).default("session_created"),
+  status: workerRunStatusEnum.default("session_created"),
+  verifyWorkflow: z.string().min(1).nullable().optional(),
 }).strict();
 
 const workerRunUpdateSchema = z.object({
-  status: z.enum(["session_created", "repo_ready", "branch_created", "edit_applied", "commit_created", "prompt_running", "push_verified", "done", "failed"]).optional(),
+  status: workerRunStatusEnum.optional(),
   lastError: z.string().nullable().optional(),
   failureSnapshotId: z.string().nullable().optional(),
   prUrl: z.string().nullable().optional(),
   verification: z.record(z.string(), z.unknown()).nullable().optional(),
+  verifyWorkflowRunId: z.string().nullable().optional(),
+  verifyWorkflowHtmlUrl: z.string().nullable().optional(),
 }).strict();
 
 const failureSnapshotCreateSchema = z.object({
@@ -675,6 +692,9 @@ export class UserControl extends DurableObject<Env> {
         last_error TEXT,
         failure_snapshot_id TEXT,
         pr_url TEXT,
+        verify_workflow TEXT,
+        verify_workflow_run_id TEXT,
+        verify_workflow_html_url TEXT,
         status TEXT NOT NULL,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
@@ -685,6 +705,14 @@ export class UserControl extends DurableObject<Env> {
       this.db.exec("ALTER TABLE worker_runs ADD COLUMN pr_url TEXT");
     } catch {
       // Column already exists.
+    }
+
+    for (const ddl of [
+      "ALTER TABLE worker_runs ADD COLUMN verify_workflow TEXT",
+      "ALTER TABLE worker_runs ADD COLUMN verify_workflow_run_id TEXT",
+      "ALTER TABLE worker_runs ADD COLUMN verify_workflow_html_url TEXT",
+    ]) {
+      try { this.db.exec(ddl); } catch { /* column already exists */ }
     }
 
     this.db.exec(`
@@ -866,8 +894,9 @@ export class UserControl extends DurableObject<Env> {
       `INSERT INTO worker_runs (
         id, session_id, parent_session_id, repo_id, repo_url, repo_dir, branch, base_branch,
         strategy, title, commit_message, expected_files_json, verification_json, last_error,
-        failure_snapshot_id, pr_url, status, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        failure_snapshot_id, pr_url, verify_workflow, verify_workflow_run_id, verify_workflow_html_url,
+        status, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       id,
       input.sessionId,
       input.parentSessionId ?? null,
@@ -882,6 +911,9 @@ export class UserControl extends DurableObject<Env> {
       JSON.stringify(input.expectedFiles),
       null,
       null,
+      null,
+      null,
+      input.verifyWorkflow ?? null,
       null,
       null,
       input.status,
@@ -901,6 +933,8 @@ export class UserControl extends DurableObject<Env> {
            failure_snapshot_id = ?,
            pr_url = ?,
            verification_json = ?,
+           verify_workflow_run_id = ?,
+           verify_workflow_html_url = ?,
            updated_at = ?
        WHERE id = ?`,
       patch.status ?? current.status,
@@ -910,6 +944,8 @@ export class UserControl extends DurableObject<Env> {
       patch.verification === undefined
         ? (current.verification === null ? null : JSON.stringify(current.verification))
         : (patch.verification === null ? null : JSON.stringify(patch.verification)),
+      patch.verifyWorkflowRunId === undefined ? (current.verifyWorkflowRunId ?? null) : patch.verifyWorkflowRunId,
+      patch.verifyWorkflowHtmlUrl === undefined ? (current.verifyWorkflowHtmlUrl ?? null) : patch.verifyWorkflowHtmlUrl,
       nowEpoch(),
       id,
     );
@@ -952,6 +988,9 @@ export class UserControl extends DurableObject<Env> {
       title: String(row.title),
       updatedAt: epochToIso(row.updated_at),
       verification: row.verification_json === null ? null : JSON.parse(String(row.verification_json)) as Record<string, unknown>,
+      verifyWorkflow: row.verify_workflow == null ? null : String(row.verify_workflow),
+      verifyWorkflowHtmlUrl: row.verify_workflow_html_url == null ? null : String(row.verify_workflow_html_url),
+      verifyWorkflowRunId: row.verify_workflow_run_id == null ? null : String(row.verify_workflow_run_id),
     };
   }
 

--- a/test/github-actions-unit.test.ts
+++ b/test/github-actions-unit.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { triggerVerifyWorkflow, pollVerifyWorkflow } from "../src/github-actions";
+import type { Env, WorkerRunRecord } from "../src/types";
+
+const baseRun: WorkerRunRecord = {
+  baseBranch: "main",
+  branch: "feat/x",
+  commitMessage: "test",
+  createdAt: new Date().toISOString(),
+  expectedFiles: [],
+  failureSnapshotId: null,
+  id: "run-1",
+  lastError: null,
+  parentSessionId: null,
+  prUrl: null,
+  repoDir: "/dodo",
+  repoId: "dodo",
+  repoUrl: "https://github.com/jonnyparris/dodo",
+  sessionId: "sess-1",
+  status: "prompt_running",
+  strategy: "agent",
+  title: "Test run",
+  updatedAt: new Date().toISOString(),
+  verification: null,
+  verifyWorkflow: "dodo-verify.yml",
+  verifyWorkflowRunId: null,
+  verifyWorkflowHtmlUrl: null,
+};
+
+function makeEnv(token = "test-token"): Env {
+  return { GITHUB_TOKEN: token } as unknown as Env;
+}
+
+describe("triggerVerifyWorkflow", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns null when verifyWorkflow is not set", async () => {
+    const run = { ...baseRun, verifyWorkflow: null };
+    const result = await triggerVerifyWorkflow({ env: makeEnv(), run });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when repoUrl is not a github.com URL", async () => {
+    const run = { ...baseRun, repoUrl: "https://gitlab.com/foo/bar" };
+    const result = await triggerVerifyWorkflow({ env: makeEnv(), run });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no token is available", async () => {
+    const env = { GITHUB_TOKEN: undefined } as unknown as Env;
+    const result = await triggerVerifyWorkflow({ env, run: baseRun });
+    expect(result).toBeNull();
+  });
+
+  it("dispatches the workflow and returns the newly-created run id", async () => {
+    const now = Date.now();
+    const fetchMock = vi
+      .fn()
+      // 1st call: workflow_dispatch — 204 No Content
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      // 2nd call: list runs — one run created after our trigger
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        workflow_runs: [
+          { id: 999, html_url: "https://github.com/jonnyparris/dodo/actions/runs/999", created_at: new Date(now).toISOString() },
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = triggerVerifyWorkflow({ env: makeEnv(), run: baseRun });
+    // Drain the internal sleep between trigger and list.
+    await vi.advanceTimersByTimeAsync(600);
+
+    const result = await promise;
+    expect(result).toEqual({ runId: "999", htmlUrl: "https://github.com/jonnyparris/dodo/actions/runs/999" });
+
+    // Verify the dispatch call targeted the right endpoint.
+    const [triggerUrl, triggerInit] = fetchMock.mock.calls[0];
+    expect(String(triggerUrl)).toContain("/actions/workflows/dodo-verify.yml/dispatches");
+    expect(triggerInit.method).toBe("POST");
+    expect(JSON.parse(triggerInit.body)).toEqual({ ref: "feat/x" });
+  });
+
+  it("ignores stale workflow runs created before the trigger", async () => {
+    const now = Date.now();
+    // Run created 5 minutes ago — clearly unrelated.
+    const staleTs = new Date(now - 5 * 60_000).toISOString();
+    const makeStaleResponse = () => new Response(JSON.stringify({
+      workflow_runs: [{ id: 1, html_url: "x", created_at: staleTs }],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockImplementation(async () => makeStaleResponse());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = triggerVerifyWorkflow({ env: makeEnv(), run: baseRun });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+});
+
+describe("pollVerifyWorkflow", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns null when runId is missing", async () => {
+    const result = await pollVerifyWorkflow({ env: makeEnv(), run: baseRun });
+    expect(result).toBeNull();
+  });
+
+  it("returns null while the workflow is still running", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      status: "in_progress",
+      conclusion: null,
+      html_url: "https://github.com/x/y/actions/runs/1",
+      updated_at: new Date().toISOString(),
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await pollVerifyWorkflow({
+      env: makeEnv(),
+      run: { ...baseRun, verifyWorkflowRunId: "42" },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns the conclusion when the workflow completes successfully", async () => {
+    const ts = new Date().toISOString();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      status: "completed",
+      conclusion: "success",
+      html_url: "https://github.com/x/y/actions/runs/42",
+      updated_at: ts,
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await pollVerifyWorkflow({
+      env: makeEnv(),
+      run: { ...baseRun, verifyWorkflowRunId: "42" },
+    });
+    expect(result).toEqual({
+      conclusion: "success",
+      htmlUrl: "https://github.com/x/y/actions/runs/42",
+      completedAt: ts,
+    });
+  });
+
+  it("surfaces failure conclusions", async () => {
+    const ts = new Date().toISOString();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      status: "completed",
+      conclusion: "failure",
+      html_url: "https://github.com/x/y/actions/runs/99",
+      updated_at: ts,
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await pollVerifyWorkflow({
+      env: makeEnv(),
+      run: { ...baseRun, verifyWorkflowRunId: "99" },
+    });
+    expect(result?.conclusion).toBe("failure");
+  });
+});

--- a/test/github-actions-unit.test.ts
+++ b/test/github-actions-unit.test.ts
@@ -61,32 +61,79 @@ describe("triggerVerifyWorkflow", () => {
     expect(result).toBeNull();
   });
 
-  it("dispatches the workflow and returns the newly-created run id", async () => {
-    const now = Date.now();
-    const fetchMock = vi
-      .fn()
-      // 1st call: workflow_dispatch — 204 No Content
+  it("matches runs by head_sha when the branch lookup succeeds", async () => {
+    const expectedSha = "abc123def456";
+    const fetchMock = vi.fn()
+      // 1st: branch lookup — returns the expected head sha
+      .mockResolvedValueOnce(new Response(JSON.stringify({ commit: { sha: expectedSha } }), { status: 200, headers: { "content-type": "application/json" } }))
+      // 2nd: workflow_dispatch — 204
       .mockResolvedValueOnce(new Response(null, { status: 204 }))
-      // 2nd call: list runs — one run created after our trigger
+      // 3rd: list runs — the matching run has the same head_sha
       .mockResolvedValueOnce(new Response(JSON.stringify({
         workflow_runs: [
-          { id: 999, html_url: "https://github.com/jonnyparris/dodo/actions/runs/999", created_at: new Date(now).toISOString() },
+          // Decoy: older run with different sha, created within the time window
+          { id: 1, html_url: "decoy", created_at: new Date().toISOString(), head_sha: "otherSha" },
+          // Real match: head_sha matches
+          { id: 999, html_url: "https://github.com/jonnyparris/dodo/actions/runs/999", created_at: new Date().toISOString(), head_sha: expectedSha },
         ],
       }), { status: 200, headers: { "content-type": "application/json" } }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const promise = triggerVerifyWorkflow({ env: makeEnv(), run: baseRun });
-    // Drain the internal sleep between trigger and list.
     await vi.advanceTimersByTimeAsync(600);
 
     const result = await promise;
     expect(result).toEqual({ runId: "999", htmlUrl: "https://github.com/jonnyparris/dodo/actions/runs/999" });
 
-    // Verify the dispatch call targeted the right endpoint.
-    const [triggerUrl, triggerInit] = fetchMock.mock.calls[0];
+    // Branch lookup hit the right endpoint (branch is percent-encoded).
+    const [branchUrl] = fetchMock.mock.calls[0];
+    expect(String(branchUrl)).toContain("/branches/feat%2Fx");
+    // Dispatch targeted the right workflow.
+    const [triggerUrl, triggerInit] = fetchMock.mock.calls[1];
     expect(String(triggerUrl)).toContain("/actions/workflows/dodo-verify.yml/dispatches");
     expect(triggerInit.method).toBe("POST");
     expect(JSON.parse(triggerInit.body)).toEqual({ ref: "feat/x" });
+  });
+
+  it("falls back to the 2s time window when branch sha lookup fails", async () => {
+    const now = Date.now();
+    const fetchMock = vi.fn()
+      // 1st: branch lookup — 404 (branch not yet visible, or token lacks scope)
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }))
+      // 2nd: dispatch
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      // 3rd: list runs — one within the 2s window, no head_sha
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        workflow_runs: [
+          { id: 777, html_url: "https://github.com/jonnyparris/dodo/actions/runs/777", created_at: new Date(now).toISOString() },
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = triggerVerifyWorkflow({ env: makeEnv(), run: baseRun });
+    await vi.advanceTimersByTimeAsync(600);
+
+    const result = await promise;
+    expect(result).toEqual({ runId: "777", htmlUrl: "https://github.com/jonnyparris/dodo/actions/runs/777" });
+  });
+
+  it("rejects runs whose head_sha doesn't match even within the time window", async () => {
+    const expectedSha = "abc123";
+    const makeListResponse = () => new Response(JSON.stringify({
+      // Run created now but with a different head_sha — must not be picked up.
+      workflow_runs: [{ id: 1, html_url: "x", created_at: new Date().toISOString(), head_sha: "deadbeef" }],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ commit: { sha: expectedSha } }), { status: 200, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockImplementation(async () => makeListResponse());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const promise = triggerVerifyWorkflow({ env: makeEnv(), run: baseRun });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const result = await promise;
+    expect(result).toBeNull();
   });
 
   it("ignores stale workflow runs created before the trigger", async () => {
@@ -97,6 +144,8 @@ describe("triggerVerifyWorkflow", () => {
       workflow_runs: [{ id: 1, html_url: "x", created_at: staleTs }],
     }), { status: 200, headers: { "content-type": "application/json" } });
     const fetchMock = vi.fn()
+      // Branch lookup fails so we fall into the time-window path.
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }))
       .mockResolvedValueOnce(new Response(null, { status: 204 }))
       .mockImplementation(async () => makeStaleResponse());
     globalThis.fetch = fetchMock as unknown as typeof fetch;


### PR DESCRIPTION
## Summary

Closes #8. Fixes the problem where dispatched commits sometimes fail to compile because the LLM skips `npm run typecheck`/`npm test` — the sandbox can't run them, so the gate has to be external.

**Approach:** opt-in GitHub Actions workflow_dispatch, polled from `verify_worker_run`. Free for public repos, works for any repo that ships a verify workflow, no Containers, no Workers Builds (which only runs on pushes to a Worker's own repo).

## Changes

- **New dispatch param:** `verifyWorkflow?: string` on `dispatch_repo_prompt` (e.g. `"dodo-verify.yml"`). Null/unset = skip the gate (default). Callers opt in.
- **New states:** `checks_running` → `checks_passed` (inserted between `prompt_running` and `done`).
- **Three new `WorkerRunRecord` fields:** `verifyWorkflow`, `verifyWorkflowRunId`, `verifyWorkflowHtmlUrl`. Persisted via `ALTER TABLE` migrations.
- **New file:** `src/github-actions.ts` — `triggerVerifyWorkflow` + `pollVerifyWorkflow`. Token resolution mirrors `github-pr.ts` (per-user encrypted secret → env fallback). Workflow runs are identified by `head_sha` (authoritative) with a 2-second time-window fallback.
- **`verify_worker_run` is now resumable.** First call after prompt completion: remote-verify + trigger workflow → return `checks_running`. Subsequent calls: poll GitHub → still running, or transition to `checks_passed` (→ auto-PR → `done`) or `failed` (with a failure snapshot pointing at the Actions run). 30-minute hard cap on `checks_running` to cover stuck queues.
- **Dogfood workflow:** `.github/workflows/dodo-verify.yml` — Node 22 + `npm ci` + typecheck + test. Runs on `workflow_dispatch` (for dispatches) and `pull_request` targeting main (for human PRs). No duplicate runs.
- ntfy notifications fire on terminal transitions (`done`, `failed`) via the existing `sendRunNotification` hook — intermediate `checks_running`/`checks_passed` are silent to avoid spam.

## Also includes #11 fixes

This branch also carries the "deeper clone + don't pull/fetch" fix from #32, since both touch the dispatch path in the same region. If #32 merges first, this will deconflict trivially; if this merges first, #32 can close without conflict.

## Why GitHub Actions over alternatives

| Option | Verdict |
|---|---|
| **GitHub Actions** ✅ | Free for public, generous free private tier. `GITHUB_TOKEN` already available. No Cloudflare costs. |
| Containers | Rejected — idle cost is real money. |
| Workers Builds | Only runs on pushes to a Worker's own repo, not a general-purpose CI. |
| External CI (CircleCI etc.) | More accounts to manage. No. |

## Review feedback (addressed in e2cd52d)

- **B2** — 30-minute timeout on `checks_running` with a `verify_gate_timeout` failure snapshot.
- **B3** — workflow runs identified by `head_sha` (authoritative), 2-second time-window fallback (was 10s), explicit rejection of head_sha mismatches.
- **Concurrent-poll PR dedupe** — `finalizePr` short-circuits if `run.prUrl` is already set.
- **I3** — `.github/workflows/dodo-verify.yml` uses `pull_request` instead of `push`, no duplicate runs.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 376 tests pass (+11 new in `test/github-actions-unit.test.ts` covering head_sha match, branch-lookup-failure fallback, head_sha mismatch, stale-run rejection)
- [ ] Dogfood: dispatch a change to Dodo itself with `verifyWorkflow: "dodo-verify.yml"`. Confirm run transitions `prompt_running` → `checks_running` → `checks_passed` → `done`, and auto-PR opens.
- [ ] Dogfood failure path: dispatch a commit with a deliberate type error — confirm `status: failed`, failure snapshot contains the Actions URL, no PR opens.

## Backward compat

- Existing dispatches that omit `verifyWorkflow` retain today's behavior — prompt → verify-branch → auto-PR → done. No new required params.
- The new `checks_*` states are appended to the enum; old rows keep their existing status strings.
- `ALTER TABLE ... ADD COLUMN` migrations are wrapped in try/catch so they're idempotent.

🤖 Generated with OpenCode.