### PR TITLE
Phase 1 finish — routes and tools

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -716,6 +716,8 @@ export function buildToolsForThink(
   if (options?.agent?.mcp) {
     const sdkMcpTools = buildSdkMcpTools(options.agent.mcp, existingNames);
     Object.assign(tools, sdkMcpTools);
+  } else {
+    // TODO: If buildToolsForThink stops receiving agent.mcp, thread it through here so SDK MCP tools can be exposed.
   }
 
   return tools;
@@ -763,4 +765,51 @@ function buildMcpTools(gatekeepers: McpGatekeeper[], existingNames: Set<string>)
   return tools;
 }
 
+function slugifyToolNamespace(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "mcp";
+}
 
+function buildSdkMcpTools(
+  agentMcp: { listTools: () => unknown[]; callTool: (input: { name: string; arguments: unknown; serverId: string }) => Promise<unknown> },
+  existingNames: Set<string>,
+): Record<string, AnyTool> {
+  const tools: Record<string, AnyTool> = {};
+  const listedTools = agentMcp.listTools();
+  if (!Array.isArray(listedTools)) return tools;
+
+  for (const listedTool of listedTools) {
+    if (!listedTool || typeof listedTool !== "object") continue;
+    const toolInfo = listedTool as {
+      name?: string;
+      description?: string;
+      inputSchema?: Record<string, unknown>;
+      serverId?: string;
+      displayName?: string;
+      serverName?: string;
+      serverDisplayName?: string;
+    };
+    if (!toolInfo.name || !toolInfo.serverId) continue;
+
+    const displayName = toolInfo.displayName ?? toolInfo.serverDisplayName ?? toolInfo.serverName ?? toolInfo.serverId;
+    const prefixedName = `${slugifyToolNamespace(displayName)}__${toolInfo.name}`.slice(0, 64);
+    if (existingNames.has(prefixedName) || tools[prefixedName]) continue;
+
+    tools[prefixedName] = tool({
+      description: toolInfo.description ?? `MCP tool: ${toolInfo.name}`,
+      inputSchema: toolInfo.inputSchema
+        ? jsonSchema(toolInfo.inputSchema)
+        : jsonSchema({ type: "object", properties: {} }),
+      execute: async (args: unknown) => agentMcp.callTool({
+        name: toolInfo.name as string,
+        arguments: args,
+        serverId: toolInfo.serverId as string,
+      }),
+    });
+    existingNames.add(prefixedName);
+  }
+
+  return tools;
+}

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -4092,6 +4092,19 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.db.exec("DELETE FROM metadata WHERE key = ?", key);
   }
 
+  async refreshMcpState(mcpId: string): Promise<void> {
+    const servers = this.getMcpServers();
+    const server = servers.servers[mcpId];
+    if (!server) throw new Error(`MCP server not found: ${mcpId}`);
+    const url = server.server_url;
+    const name = server.name ?? new URL(url).host;
+    await this.removeMcpServer(mcpId);
+    await this.addMcpServer(name, url, {
+      callbackHost: this.env.WORKER_URL,
+      callbackPath: "/agents",
+    });
+  }
+
   /**
    * Connect to enabled MCP servers for this session.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -916,6 +916,66 @@ app.post("/api/mcp-configs/:id/test", async (c) => {
   return proxyToUserControl(c.env, email, `/mcp-configs/${encodeURIComponent(c.req.param("id"))}/test`, { method: "POST" });
 });
 
+// OAuth callback route for MCP server auth flows
+app.all("/agents/*", async (c) => {
+  const userEmail = c.get("userEmail");
+  const id = c.env.CODING_AGENT.idFromName(userEmail);
+  const stub = c.env.CODING_AGENT.get(id);
+  return stub.fetch(c.req.raw);
+});
+
+// Start MCP OAuth flow
+app.post("/api/mcp/start-auth", async (c) => {
+  const { mcpUrl } = await c.req.json<{ mcpUrl: string }>();
+  if (!mcpUrl) return c.json({ error: "mcpUrl required" }, 400);
+
+  const userEmail = c.get("userEmail");
+  const id = c.env.CODING_AGENT.idFromName(userEmail);
+  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+    addMcpServer: (name: string, url: string, opts: { callbackHost: string; callbackPath: string }) => Promise<{ state: string; authUrl?: string; id: string }>;
+  };
+
+  const displayName = new URL(mcpUrl).host;
+
+  const result = await stub.addMcpServer(displayName, mcpUrl, {
+    callbackHost: c.env.WORKER_URL,
+    callbackPath: "/agents",
+  });
+
+  if (result.state === "authenticating") {
+    return c.json({ authUrl: result.authUrl });
+  }
+  return c.json({ message: "Connected" });
+});
+
+// Delete an MCP OAuth connection
+app.post("/api/mcp/delete-auth", async (c) => {
+  const { mcpId } = await c.req.json<{ mcpId: string }>();
+  if (!mcpId) return c.json({ error: "mcpId required" }, 400);
+
+  const userEmail = c.get("userEmail");
+  const id = c.env.CODING_AGENT.idFromName(userEmail);
+  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+    removeMcpServer: (id: string) => Promise<void>;
+  };
+  await stub.removeMcpServer(mcpId);
+  return c.json({ ok: true });
+});
+
+// Refresh an MCP connection (remove + re-add)
+app.post("/api/mcp/refresh-state", async (c) => {
+  const { mcpId } = await c.req.json<{ mcpId: string }>();
+  if (!mcpId) return c.json({ error: "mcpId required" }, 400);
+
+  const userEmail = c.get("userEmail");
+  const id = c.env.CODING_AGENT.idFromName(userEmail);
+  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+    refreshMcpState: (id: string) => Promise<void>;
+  };
+  await stub.refreshMcpState(mcpId);
+  return c.json({ ok: true });
+});
+
 // ─── MCP Catalog (static) ───
 
 app.get("/api/mcp-catalog", (c) => c.json(MCP_CATALOG));


### PR DESCRIPTION
## Summary

Auto-generated by Dodo worker run `970ac3da-5748-4a75-852e-65f631ee8197`.

feat: add /agents/* OAuth callback route and /api/mcp/* endpoints

## Metadata

- Branch: `feat/mcp-oauth-phase1-routes`
- Base: `feat/mcp-oauth-phase1`
- Session: `2343d4fb-384a-4502-b130-a9cb53c2940f`
- Strategy: `agent`
- Verification: `{"aheadBy":1,"baseRef":"feat/mcp-oauth-phase1","branch":"feat/mcp-oauth-phase1-routes","changedFiles":["src/agentic.ts","src/coding-agent.ts","src/index.ts"],"compareUrl":"https://api.github.com/repos/jonnyparris/dodo/compare/feat%2Fmcp-oauth-phase1...feat%2Fmcp-oauth-phase1-routes","ok":true,"provider":"github","remoteUrl":"https://github.com/jonnyparris/dodo","verifyGate":{"triggered":false,"reason":"workflow_dispatch failed or missing token"}}`

---

🤖 Drafted via `dodo_dispatch_repo_prompt`.