### PR TITLE
Phase 1 — fix typecheck errors

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -19,6 +19,7 @@ export interface BuildToolsOptions {
   ownerId?: string;
   ownerEmail?: string;
   stateBackend?: StateBackend;
+  mcpGatekeepers?: McpGatekeeper[];
   /** Session ID — required to scope attachment R2 keys. */
   sessionId?: string;
   /**
@@ -702,7 +703,7 @@ export function buildToolsForThink(
   env: Env,
   workspace: Workspace,
   config: AppConfig,
-  options?: BuildToolsOptions & { agent?: { mcp?: { listTools: () => unknown[]; callTool: (input: { name: string; arguments: unknown; serverId: string }) => Promise<unknown> } } },
+  options?: BuildToolsOptions & { agent?: { mcp?: { listTools: () => unknown[]; callTool: (input: unknown) => Promise<unknown> } } },
 ): Record<string, AnyTool> {
   const tools = buildTools(env, workspace, config, options);
   const existingNames = new Set(Object.keys(tools));
@@ -773,7 +774,7 @@ function slugifyToolNamespace(name: string): string {
 }
 
 function buildSdkMcpTools(
-  agentMcp: { listTools: () => unknown[]; callTool: (input: { name: string; arguments: unknown; serverId: string }) => Promise<unknown> },
+  agentMcp: { listTools: () => unknown[]; callTool: (input: unknown) => Promise<unknown> },
   existingNames: Set<string>,
 ): Record<string, AnyTool> {
   const tools: Record<string, AnyTool> = {};

--- a/test/mcp-config.test.ts
+++ b/test/mcp-config.test.ts
@@ -205,6 +205,7 @@ describe("McpGatekeeper interface", () => {
       type: "http" as const,
       url: "https://mcp-test.example.com",
       headers: { Authorization: "Bearer abc" },
+      auth_type: "static_headers",
       enabled: true,
     };
 
@@ -220,6 +221,7 @@ describe("McpGatekeeper interface", () => {
       id: "wrong-type",
       name: "Wrong Type",
       type: "service-binding",
+      auth_type: "static_headers",
       enabled: true,
     })).toThrow(/only supports type "http"/);
   });
@@ -231,6 +233,7 @@ describe("McpGatekeeper interface", () => {
       id: "no-url",
       name: "No URL",
       type: "http",
+      auth_type: "static_headers",
       enabled: true,
     })).toThrow(/requires a url/);
   });

--- a/test/mcp-gatekeeper-unit.test.ts
+++ b/test/mcp-gatekeeper-unit.test.ts
@@ -15,6 +15,7 @@ describe("HttpMcpGatekeeper interface", () => {
       type: "http" as const,
       url: "https://mcp-test.example.com",
       headers: { Authorization: "Bearer abc" },
+      auth_type: "static_headers",
       enabled: true,
     };
 
@@ -30,6 +31,7 @@ describe("HttpMcpGatekeeper interface", () => {
       id: "wrong-type",
       name: "Wrong Type",
       type: "service-binding",
+      auth_type: "static_headers",
       enabled: true,
     })).toThrow(/only supports type "http"/);
   });
@@ -41,6 +43,7 @@ describe("HttpMcpGatekeeper interface", () => {
       id: "no-url",
       name: "No URL",
       type: "http",
+      auth_type: "static_headers",
       enabled: true,
     })).toThrow(/requires a url/);
   });


### PR DESCRIPTION
## Summary

Auto-generated by Dodo worker run `809507e8-220c-46a2-a874-0babee348a77`.

fix: typecheck errors in OAuth MCP Phase 1 — auth_type on test fixtures, callTool signature, mcpGatekeepers option typing

## Metadata

- Branch: `fix/mcp-oauth-phase1-typecheck`
- Base: `feat/mcp-oauth-phase1-routes`
- Session: `a09cf30c-2f8d-4ff7-9ace-0f1b96d090a4`
- Strategy: `agent`
- Verification: `{"aheadBy":1,"baseRef":"feat/mcp-oauth-phase1-routes","branch":"fix/mcp-oauth-phase1-typecheck","changedFiles":["src/agentic.ts","test/mcp-config.test.ts","test/mcp-gatekeeper-unit.test.ts"],"compareUrl":"https://api.github.com/repos/jonnyparris/dodo/compare/feat%2Fmcp-oauth-phase1-routes...fix%2Fmcp-oauth-phase1-typecheck","ok":true,"provider":"github","remoteUrl":"https://github.com/jonnyparris/dodo","verifyGate":{"triggered":false,"reason":"workflow_dispatch failed or missing token"}}`

---

🤖 Drafted via `dodo_dispatch_repo_prompt`.