### PR TITLE
Phase 2 — fix: restore MCP_CATALOG import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { runHealthCheck } from "./health-check";
 import { log } from "./logger";
 import { createDodoMcpServer } from "./mcp";
 import { createDodoCodeModeMcpServer } from "./mcp-codemode";
+import { MCP_CATALOG } from "./mcp-catalog";
 import { fetchAttachment } from "./attachments";
 import { AllowlistOutbound } from "./outbound";
 import { RateLimiter } from "./rate-limit";


### PR DESCRIPTION
## Summary

Auto-generated by Dodo worker run `0167bf7c-8c17-41e1-84e2-397ad6c4a444`.

fix: restore MCP_CATALOG import in src/index.ts for host allowlist

## Metadata

- Branch: `fix/mcp-oauth-phase2-import`
- Base: `feat/mcp-oauth-phase2`
- Session: `dff6a692-1123-4cfc-aa11-91f43d4c7d4b`
- Strategy: `agent`
- Verification: `{"aheadBy":1,"baseRef":"feat/mcp-oauth-phase2","branch":"fix/mcp-oauth-phase2-import","changedFiles":["src/index.ts"],"compareUrl":"https://api.github.com/repos/jonnyparris/dodo/compare/feat%2Fmcp-oauth-phase2...fix%2Fmcp-oauth-phase2-import","ok":true,"provider":"github","remoteUrl":"https://github.com/jonnyparris/dodo","verifyGate":{"triggered":false,"reason":"workflow_dispatch failed or missing token"}}`

---

🤖 Drafted via `dodo_dispatch_repo_prompt`.