### PR TITLE
Add /generate slash command for FLUX-1-schnell image generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -949,7 +949,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -966,7 +965,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -983,7 +981,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,7 +997,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,7 +1013,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1034,7 +1029,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1051,7 +1045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1068,7 +1061,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1085,7 +1077,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,7 +1093,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,7 +1109,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1136,7 +1125,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1153,7 +1141,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1170,7 +1157,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1187,7 +1173,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1204,7 +1189,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1221,7 +1205,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,7 +1221,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,7 +1237,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,7 +1253,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,7 +1269,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1306,7 +1285,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,7 +1301,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1340,7 +1317,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,7 +1333,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1374,7 +1349,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3628,7 +3602,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4009,7 +3983,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4559,7 +4532,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4580,7 +4552,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4601,7 +4572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4622,7 +4592,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4643,7 +4612,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4664,7 +4632,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4685,7 +4652,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4706,7 +4672,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4727,7 +4692,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4748,7 +4712,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4769,7 +4732,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/public/js/dodo-chat.js
+++ b/public/js/dodo-chat.js
@@ -444,6 +444,19 @@ async function sendMessage(){
   sendTypingStop();
   if(!currentSession){const d=await jsonSafe("/session",{});if(!d)return;currentSession=d.id;await selectSession(d.id)}
   $("msg-input").value="";$("msg-input").style.height='auto';clearPendingImages();
+
+  // Detect /generate slash command for image generation
+  const generateMatch=content.match(/^\/generate\s+(.+)$/i);
+  if(generateMatch){
+    const prompt=generateMatch[1].trim();
+    if(!prompt)return toast("Add a prompt after /generate","warning");
+    if(isProcessing)return toast("Wait for the current response before generating","warning");
+    setProcessing(true);showThinking();
+    const result=await jsonSafe(`/session/${currentSession}/generate`,{content:prompt});
+    if(!result){setProcessing(false);hideThinking()}
+    return;
+  }
+
   const payload=images?{content,images}:{content};
   if(isProcessing){
     // Queue text-only prompts. Image-carrying prompts are blocked above.

--- a/public/js/dodo-chat.js
+++ b/public/js/dodo-chat.js
@@ -445,8 +445,9 @@ async function sendMessage(){
   if(!currentSession){const d=await jsonSafe("/session",{});if(!d)return;currentSession=d.id;await selectSession(d.id)}
   $("msg-input").value="";$("msg-input").style.height='auto';clearPendingImages();
 
-  // Detect /generate slash command for image generation
-  const generateMatch=content.match(/^\/generate\s+(.+)$/i);
+  // Detect /generate slash command for image generation.
+  // `[\s\S]+` (not `.+`) so multi-line prompts survive — `.` doesn't cross newlines by default.
+  const generateMatch=content.match(/^\/generate\s+([\s\S]+)$/i);
   if(generateMatch){
     const prompt=generateMatch[1].trim();
     if(!prompt)return toast("Add a prompt after /generate","warning");

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -33,7 +33,7 @@ import {
 } from "./think-adapter";
 import type { SnapshotV2 } from "./think-adapter";
 import type { AppConfig, ChatMessageRecord, CronJobRecord, Env, PromptRecord, SessionEvent, SessionSnapshot, SessionState, WorkspaceEntry } from "./types";
-import { FALLBACK_MODELS, WORKERS_AI_MODELS } from "./shared-index";
+import { FALLBACK_MODELS, WORKERS_AI_MODELS, FLUX_IMAGE_MODEL, FLUX_IMAGE_MEDIA_TYPE, FLUX_MAX_PROMPT_LENGTH } from "./shared-index";
 
 /**
  * Context window sizes (in tokens) by model ID. Used for token budget enforcement.
@@ -117,6 +117,10 @@ const imageAttachmentSchema = z.object({
 const sendMessageSchema = z.object({
   content: z.string().trim().min(1),
   images: z.array(imageAttachmentSchema).max(MAX_IMAGES_PER_MESSAGE).optional(),
+}).strict();
+/** /generate schema — FLUX-1-schnell rejects >2048 chars, so enforce at the edge. */
+const generateImageSchema = z.object({
+  content: z.string().trim().min(1).max(FLUX_MAX_PROMPT_LENGTH),
 }).strict();
 const executeCodeSchema = z.object({ code: z.string().trim().min(1) }).strict();
 const gitCommitSchema = z.object({ dir: z.string().optional(), message: z.string().trim().min(1) }).strict();
@@ -2945,7 +2949,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
   }
 
   private async handleGenerate(request: Request): Promise<Response> {
-    const input = sendMessageSchema.parse(await request.json());
+    const input = generateImageSchema.parse(await request.json());
     const sessionId = this.requireSessionId(request);
     const authorEmail = request.headers.get("x-author-email");
     const ownerEmail = request.headers.get("x-owner-email");
@@ -2955,6 +2959,14 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const thinkSessionId = this.getCurrentSessionId();
     if (!thinkSessionId) {
       return Response.json({ error: "No Think session" }, { status: 500 });
+    }
+
+    // Reject when another prompt is already running so we don't corrupt
+    // `active_prompt_id` or dequeue another user's queued prompt on finish.
+    // Matches `handleMessage`'s 409 behaviour — /generate is synchronous so
+    // queueing would lose the response anyway.
+    if (this.readMetadata("active_prompt_id")) {
+      return Response.json({ error: "A prompt is already running" }, { status: 409 });
     }
 
     const promptId = crypto.randomUUID();
@@ -2968,121 +2980,40 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.emitEvent({ data: this.readSessionDetails(), type: "state" });
 
     try {
-      // 1. Persist user message
-      const userMsgId = crypto.randomUUID();
-      const userMsg: UIMessage = {
-        id: userMsgId,
-        role: "user",
-        parts: [{ type: "text", text: input.content }],
-      };
-      this.sessions.append(thinkSessionId, userMsg);
-      this.insertMessageMetadata({
-        messageId: userMsgId,
-        authorEmail: authorEmail ?? null,
-        model: null,
-        provider: null,
-        tokenInput: 0,
-        tokenOutput: 0,
-      });
-      const userRecord = uiMessageToChatRecord(userMsg, {
-        messageId: userMsgId,
-        authorEmail: authorEmail ?? null,
-        model: null,
-        provider: null,
-        tokenInput: 0,
-        tokenOutput: 0,
-        createdAt: nowEpoch(),
-      });
-      this.emitEvent({ data: userRecord, type: "message" });
+      // 1. Persist user prompt message
+      const userMsgId = this.persistGenerateUserMessage(thinkSessionId, input.content, authorEmail);
 
-      // 2. Generate image via Workers AI
-      const fluxResult = await this.env.AI.run("@cf/black-forest-labs/flux-1-schnell", {
+      // 2. Generate image via Workers AI. Pass a random seed so repeat
+      //    invocations of the same prompt don't collapse to identical output.
+      const raw = await this.env.AI.run(FLUX_IMAGE_MODEL, {
         prompt: input.content,
-      }) as { image: string };
+        seed: Math.floor(Math.random() * 1_000_000),
+      });
+      // Defensive parsing — type assertions would silently break if the
+      // Workers AI response shape ever drifts (it already has for FLUX.2).
+      if (!raw || typeof raw !== "object" || typeof (raw as { image?: unknown }).image !== "string" || !(raw as { image: string }).image) {
+        throw new Error("FLUX returned unexpected response shape");
+      }
+      const imageData = (raw as { image: string }).image;
 
-      // 3. Create assistant message with the generated image
-      const assistantMsgId = crypto.randomUUID();
-      const imageData = fluxResult.image;
-      const mediaType = "image/jpeg";
-
-      // Upload to R2
-      const attachmentRef = await uploadAttachment(this.env, {
+      // 3. Persist assistant message with the generated image
+      const assistantResult = await this.persistGeneratedImageMessage({
+        thinkSessionId,
         sessionId,
-        messageId: assistantMsgId,
-        mediaType,
-        data: imageData,
-        source: "assistant",
+        prompt: input.content,
+        imageData,
         ownerEmail: ownerEmail ?? undefined,
       });
 
-      const assistantParts: UIMessage["parts"] = [
-        { type: "text", text: `Generated image for: "${input.content}"` },
-      ];
-      if (attachmentRef) {
-        assistantParts.push({
-          type: "file",
-          mediaType,
-          url: attachmentRef.url,
-        } as FileUIPart);
-      }
-
-      const assistantMsg: UIMessage = {
-        id: assistantMsgId,
-        role: "assistant",
-        parts: assistantParts,
-      };
-      this.sessions.append(thinkSessionId, assistantMsg);
-      this.insertMessageMetadata({
-        messageId: assistantMsgId,
-        authorEmail: null,
-        model: "@cf/black-forest-labs/flux-1-schnell",
-        provider: "Workers AI",
-        tokenInput: 0,
-        tokenOutput: 0,
-      });
-
-      if (attachmentRef) {
-        this.insertMessageAttachment({
-          messageId: assistantMsgId,
-          mediaType,
-          url: attachmentRef.url,
-          size: attachmentRef.size,
-          source: "assistant",
-        });
-      }
-
-      const assistantRecord = uiMessageToChatRecord(assistantMsg, {
-        messageId: assistantMsgId,
-        authorEmail: null,
-        model: "@cf/black-forest-labs/flux-1-schnell",
-        provider: "Workers AI",
-        tokenInput: 0,
-        tokenOutput: 0,
-        createdAt: nowEpoch(),
-      });
-
-      // Emit message + attachments events
-      this.emitEvent({ data: assistantRecord, type: "message" });
-      if (attachmentRef) {
-        this.emitEvent({
-          data: {
-            messageId: assistantMsgId,
-            attachments: rewriteAttachmentsForClient([
-              { mediaType: attachmentRef.mediaType, url: attachmentRef.url, size: attachmentRef.size },
-            ]),
-          },
-          type: "message_attachments",
-        });
-      }
-
-      await this.finishPrompt(promptId, { resultMessageId: assistantMsgId, status: "completed" });
+      await this.finishPrompt(promptId, { resultMessageId: assistantResult.messageId, status: "completed" });
       this.emitEvent({ data: this.readSessionDetails(), type: "state" });
       this.emitEvent({ data: this.listPrompts(), type: "prompt" });
 
       return Response.json({
-        message: assistantRecord,
+        message: assistantResult.record,
         promptId,
         status: "completed",
+        userMsgId,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Image generation failed";
@@ -3092,6 +3023,130 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       this.emitEvent({ data: this.listPrompts(), type: "prompt" });
       return Response.json({ error: message }, { status: 502 });
     }
+  }
+
+  /** Persist the user's /generate prompt as a regular text message and emit a
+   *  `message` SSE event so the UI renders it identically to a chat prompt. */
+  private persistGenerateUserMessage(thinkSessionId: string, content: string, authorEmail: string | null): string {
+    const userMsgId = crypto.randomUUID();
+    const userMsg: UIMessage = {
+      id: userMsgId,
+      role: "user",
+      parts: [{ type: "text", text: content }],
+    };
+    this.sessions.append(thinkSessionId, userMsg);
+    this.insertMessageMetadata({
+      messageId: userMsgId,
+      authorEmail: authorEmail ?? null,
+      model: null,
+      provider: null,
+      tokenInput: 0,
+      tokenOutput: 0,
+    });
+    const userRecord = uiMessageToChatRecord(userMsg, {
+      messageId: userMsgId,
+      authorEmail: authorEmail ?? null,
+      model: null,
+      provider: null,
+      tokenInput: 0,
+      tokenOutput: 0,
+      createdAt: nowEpoch(),
+    });
+    this.emitEvent({ data: userRecord, type: "message" });
+    return userMsgId;
+  }
+
+  /** Upload the FLUX-generated image to R2 and persist it as an assistant
+   *  message. If R2 is unavailable the message falls back to an inline data
+   *  URL so the user still sees the image rather than a silent stub — this
+   *  matches the design contract in `src/attachments.ts`. */
+  private async persistGeneratedImageMessage(opts: {
+    thinkSessionId: string;
+    sessionId: string;
+    prompt: string;
+    imageData: string;
+    ownerEmail: string | undefined;
+  }): Promise<{ messageId: string; record: ChatMessageRecord }> {
+    const assistantMsgId = crypto.randomUUID();
+    const mediaType = FLUX_IMAGE_MEDIA_TYPE;
+
+    const attachmentRef = await uploadAttachment(this.env, {
+      sessionId: opts.sessionId,
+      messageId: assistantMsgId,
+      mediaType,
+      data: opts.imageData,
+      source: "assistant",
+      ownerEmail: opts.ownerEmail,
+    });
+
+    // Short, non-verbose caption — the image carries the meaning. Truncate the
+    // prompt so a 2000-char prompt doesn't dominate the bubble.
+    const preview = opts.prompt.length > 80 ? `${opts.prompt.slice(0, 80).trimEnd()}…` : opts.prompt;
+    const assistantParts: UIMessage["parts"] = [
+      { type: "text", text: `🎨 ${preview}` },
+    ];
+    // Prefer the R2-backed URL; fall back to an inline data URL when R2 is
+    // unavailable so the UI still renders something useful in local dev.
+    const imageUrl = attachmentRef?.url ?? `data:${mediaType};base64,${opts.imageData}`;
+    assistantParts.push({
+      type: "file",
+      mediaType,
+      url: imageUrl,
+    } as FileUIPart);
+
+    const assistantMsg: UIMessage = {
+      id: assistantMsgId,
+      role: "assistant",
+      parts: assistantParts,
+    };
+    this.sessions.append(opts.thinkSessionId, assistantMsg);
+    this.insertMessageMetadata({
+      messageId: assistantMsgId,
+      authorEmail: null,
+      model: FLUX_IMAGE_MODEL,
+      provider: "Workers AI",
+      tokenInput: 0,
+      tokenOutput: 0,
+    });
+
+    if (attachmentRef) {
+      this.insertMessageAttachment({
+        messageId: assistantMsgId,
+        mediaType,
+        url: attachmentRef.url,
+        size: attachmentRef.size,
+        source: "assistant",
+      });
+    } else {
+      log("warn", "persistGeneratedImageMessage: R2 unavailable, falling back to inline data URL", {
+        sessionId: opts.sessionId,
+      });
+    }
+
+    const record = uiMessageToChatRecord(assistantMsg, {
+      messageId: assistantMsgId,
+      authorEmail: null,
+      model: FLUX_IMAGE_MODEL,
+      provider: "Workers AI",
+      tokenInput: 0,
+      tokenOutput: 0,
+      createdAt: nowEpoch(),
+    });
+
+    this.emitEvent({ data: record, type: "message" });
+    if (attachmentRef) {
+      this.emitEvent({
+        data: {
+          messageId: assistantMsgId,
+          attachments: rewriteAttachmentsForClient([
+            { mediaType: attachmentRef.mediaType, url: attachmentRef.url, size: attachmentRef.size },
+          ]),
+        },
+        type: "message_attachments",
+      });
+    }
+
+    return { messageId: assistantMsgId, record };
   }
 
   private async handleAbort(): Promise<Response> {

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1992,6 +1992,10 @@ export class CodingAgent extends Think<Env, DodoConfig> {
         return await this.handlePrompt(request);
       }
 
+      if (request.method === "POST" && url.pathname === "/generate") {
+        return await this.handleGenerate(request);
+      }
+
       if (request.method === "POST" && url.pathname === "/abort") {
         return await this.handleAbort();
       }
@@ -2938,6 +2942,156 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.setPromptFiberId(promptId, fiberId);
 
     return Response.json({ promptId, status: "queued" }, { status: 202 });
+  }
+
+  private async handleGenerate(request: Request): Promise<Response> {
+    const input = sendMessageSchema.parse(await request.json());
+    const sessionId = this.requireSessionId(request);
+    const authorEmail = request.headers.get("x-author-email");
+    const ownerEmail = request.headers.get("x-owner-email");
+    this.ensureMetadata(sessionId, ownerEmail);
+    this.ensureThinkConfig(request);
+
+    const thinkSessionId = this.getCurrentSessionId();
+    if (!thinkSessionId) {
+      return Response.json({ error: "No Think session" }, { status: 500 });
+    }
+
+    const promptId = crypto.randomUUID();
+    const title = this.readMetadata("title") ?? (input.content.length > 72 ? input.content.slice(0, 72) + "…" : input.content);
+
+    this.writeMetadata("title", title);
+    this.writeMetadata("active_prompt_id", promptId);
+    this.writeMetadata("status", "running");
+    this.insertPrompt(promptId, input.content, "queued", authorEmail);
+    await this.syncSessionIndex({ status: "running", title });
+    this.emitEvent({ data: this.readSessionDetails(), type: "state" });
+
+    try {
+      // 1. Persist user message
+      const userMsgId = crypto.randomUUID();
+      const userMsg: UIMessage = {
+        id: userMsgId,
+        role: "user",
+        parts: [{ type: "text", text: input.content }],
+      };
+      this.sessions.append(thinkSessionId, userMsg);
+      this.insertMessageMetadata({
+        messageId: userMsgId,
+        authorEmail: authorEmail ?? null,
+        model: null,
+        provider: null,
+        tokenInput: 0,
+        tokenOutput: 0,
+      });
+      const userRecord = uiMessageToChatRecord(userMsg, {
+        messageId: userMsgId,
+        authorEmail: authorEmail ?? null,
+        model: null,
+        provider: null,
+        tokenInput: 0,
+        tokenOutput: 0,
+        createdAt: nowEpoch(),
+      });
+      this.emitEvent({ data: userRecord, type: "message" });
+
+      // 2. Generate image via Workers AI
+      const fluxResult = await this.env.AI.run("@cf/black-forest-labs/flux-1-schnell", {
+        prompt: input.content,
+      }) as { image: string };
+
+      // 3. Create assistant message with the generated image
+      const assistantMsgId = crypto.randomUUID();
+      const imageData = fluxResult.image;
+      const mediaType = "image/jpeg";
+
+      // Upload to R2
+      const attachmentRef = await uploadAttachment(this.env, {
+        sessionId,
+        messageId: assistantMsgId,
+        mediaType,
+        data: imageData,
+        source: "assistant",
+        ownerEmail: ownerEmail ?? undefined,
+      });
+
+      const assistantParts: UIMessage["parts"] = [
+        { type: "text", text: `Generated image for: "${input.content}"` },
+      ];
+      if (attachmentRef) {
+        assistantParts.push({
+          type: "file",
+          mediaType,
+          url: attachmentRef.url,
+        } as FileUIPart);
+      }
+
+      const assistantMsg: UIMessage = {
+        id: assistantMsgId,
+        role: "assistant",
+        parts: assistantParts,
+      };
+      this.sessions.append(thinkSessionId, assistantMsg);
+      this.insertMessageMetadata({
+        messageId: assistantMsgId,
+        authorEmail: null,
+        model: "@cf/black-forest-labs/flux-1-schnell",
+        provider: "Workers AI",
+        tokenInput: 0,
+        tokenOutput: 0,
+      });
+
+      if (attachmentRef) {
+        this.insertMessageAttachment({
+          messageId: assistantMsgId,
+          mediaType,
+          url: attachmentRef.url,
+          size: attachmentRef.size,
+          source: "assistant",
+        });
+      }
+
+      const assistantRecord = uiMessageToChatRecord(assistantMsg, {
+        messageId: assistantMsgId,
+        authorEmail: null,
+        model: "@cf/black-forest-labs/flux-1-schnell",
+        provider: "Workers AI",
+        tokenInput: 0,
+        tokenOutput: 0,
+        createdAt: nowEpoch(),
+      });
+
+      // Emit message + attachments events
+      this.emitEvent({ data: assistantRecord, type: "message" });
+      if (attachmentRef) {
+        this.emitEvent({
+          data: {
+            messageId: assistantMsgId,
+            attachments: rewriteAttachmentsForClient([
+              { mediaType: attachmentRef.mediaType, url: attachmentRef.url, size: attachmentRef.size },
+            ]),
+          },
+          type: "message_attachments",
+        });
+      }
+
+      await this.finishPrompt(promptId, { resultMessageId: assistantMsgId, status: "completed" });
+      this.emitEvent({ data: this.readSessionDetails(), type: "state" });
+      this.emitEvent({ data: this.listPrompts(), type: "prompt" });
+
+      return Response.json({
+        message: assistantRecord,
+        promptId,
+        status: "completed",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Image generation failed";
+      this.emitEvent({ data: { message }, type: "error_message" });
+      await this.finishPrompt(promptId, { error: message, status: "failed" });
+      this.emitEvent({ data: this.readSessionDetails(), type: "state" });
+      this.emitEvent({ data: this.listPrompts(), type: "prompt" });
+      return Response.json({ error: message }, { status: 502 });
+    }
   }
 
   private async handleAbort(): Promise<Response> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1352,6 +1352,19 @@ app.post("/session/:id/prompt", async (c) => {
   });
 });
 
+app.post("/session/:id/generate", async (c) => {
+  const denied = requirePermission(c, "write");
+  if (denied) return denied;
+  const email = c.get("userEmail");
+  const rl = promptLimiter.check(`generate:${email}`, 30, 60 * 60 * 1000);
+  if (!rl.allowed) return rateLimitedResponse(rl, "generate", email);
+  const ownerEmail = c.get("sessionOwnerEmail") || email;
+  return proxyToAgent(c.req.raw, c.env, c.req.param("id"), "/generate", {
+    "x-author-email": email,
+    "x-owner-email": ownerEmail,
+  });
+});
+
 app.get("/session/:id/ws", async (c) => {
   const upgradeHeader = c.req.header("Upgrade");
   if (!upgradeHeader || upgradeHeader.toLowerCase() !== "websocket") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1356,8 +1356,12 @@ app.post("/session/:id/generate", async (c) => {
   const denied = requirePermission(c, "write");
   if (denied) return denied;
   const email = c.get("userEmail");
-  const rl = promptLimiter.check(`generate:${email}`, 30, 60 * 60 * 1000);
-  if (!rl.allowed) return rateLimitedResponse(rl, "generate", email);
+  // Hourly cap bounds burst traffic, daily cap bounds long-horizon cost
+  // exposure — FLUX is pay-per-call so we want both ceilings.
+  const hourly = promptLimiter.check(`generate-hr:${email}`, 30, 60 * 60 * 1000);
+  if (!hourly.allowed) return rateLimitedResponse(hourly, "generate", email);
+  const daily = promptLimiter.check(`generate-day:${email}`, 100, 24 * 60 * 60 * 1000);
+  if (!daily.allowed) return rateLimitedResponse(daily, "generate", email);
   const ownerEmail = c.get("sessionOwnerEmail") || email;
   return proxyToAgent(c.req.raw, c.env, c.req.param("id"), "/generate", {
     "x-author-email": email,

--- a/src/shared-index.ts
+++ b/src/shared-index.ts
@@ -32,6 +32,7 @@ export const WORKERS_AI_MODELS = [
   { id: "@cf/google/gemma-4-26b-a4b-it", name: "Gemma 4 26B A4B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 256_000 },
   { id: "@cf/meta/llama-4-scout-17b-16e-instruct", name: "Llama 4 Scout 17B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 131_072 },
   { id: "@cf/qwen/qwen2.5-coder-32b-instruct", name: "Qwen 2.5 Coder 32B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 32_768 },
+  { id: "@cf/black-forest-labs/flux-1-schnell", name: "FLUX.1 Schnell (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 0 },
 ];
 
 /** Provider prefixes the opencode gateway can actually route.

--- a/src/shared-index.ts
+++ b/src/shared-index.ts
@@ -24,16 +24,28 @@ export const FALLBACK_MODELS = [
   { id: "deepseek/deepseek-reasoner", name: "DeepSeek Reasoner", provider: "DeepSeek", costInput: 0.55, costOutput: 2.19, contextWindow: 128_000 },
 ];
 
-/** Workers AI models available via AI Gateway's unified OpenAI-compatible endpoint.
- *  Routed with the `workers-ai/` prefix per https://developers.cloudflare.com/ai-gateway/chat-completion/
- *  These only work when `activeGateway === "ai-gateway"`. */
+/** Workers AI chat/text models — advertised in the model picker so users can
+ *  set them as their session default. Routed via AI Gateway's OpenAI-compatible
+ *  endpoint. These only work when `activeGateway === "ai-gateway"`. */
 export const WORKERS_AI_MODELS = [
   { id: "@cf/moonshotai/kimi-k2.6", name: "Kimi K2.6 (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 262_144 },
   { id: "@cf/google/gemma-4-26b-a4b-it", name: "Gemma 4 26B A4B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 256_000 },
   { id: "@cf/meta/llama-4-scout-17b-16e-instruct", name: "Llama 4 Scout 17B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 131_072 },
   { id: "@cf/qwen/qwen2.5-coder-32b-instruct", name: "Qwen 2.5 Coder 32B (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 32_768 },
-  { id: "@cf/black-forest-labs/flux-1-schnell", name: "FLUX.1 Schnell (Workers AI)", provider: "Workers AI", costInput: null, costOutput: null, contextWindow: 0 },
 ];
+
+/** Workers AI image-generation models. Not surfaced in the chat model picker —
+ *  they're invoked via dedicated endpoints (e.g. POST /session/:id/generate).
+ *  Kept here so the catalog is documented in one place. */
+export const WORKERS_AI_IMAGE_MODELS = [
+  { id: "@cf/black-forest-labs/flux-1-schnell", name: "FLUX.1 Schnell", provider: "Workers AI", kind: "text-to-image" },
+];
+
+/** Default model for /generate. Central constant so tests and handlers stay in sync. */
+export const FLUX_IMAGE_MODEL = "@cf/black-forest-labs/flux-1-schnell";
+export const FLUX_IMAGE_MEDIA_TYPE = "image/jpeg";
+/** FLUX-1-schnell API limit per the model schema (developers.cloudflare.com/workers-ai/models/flux-1-schnell). */
+export const FLUX_MAX_PROMPT_LENGTH = 2048;
 
 /** Provider prefixes the opencode gateway can actually route.
  *  The models.dev provider TOMLs often fall back to `anthropic/` for non-Anthropic models

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type { SharedIndex } from "./shared-index";
 import type { UserControl } from "./user-control";
 
 export interface Env {
+  AI: Ai;
   AI_GATEWAY_BASE_URL: string;
   AI_GATEWAY_DEFAULT_MODEL?: string;
   AI_GATEWAY_KEY?: string;

--- a/test/generate-unit.test.ts
+++ b/test/generate-unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the /generate image-generation flow.
+ *
+ * The live Workers AI FLUX call can't be exercised under vitest-pool-workers —
+ * miniflare doesn't mock `env.AI.run()` and the handler lives inside a DO
+ * (not trivially injectable). These tests cover the edges that don't need the
+ * DO path:
+ *
+ *   - Client-side `/generate` slash command regex (public/js/dodo-chat.js)
+ *   - Server-side prompt schema (max 2048 chars per FLUX docs)
+ *   - Shared-index catalog separation (chat models vs image models)
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  FLUX_IMAGE_MODEL,
+  FLUX_IMAGE_MEDIA_TYPE,
+  FLUX_MAX_PROMPT_LENGTH,
+  WORKERS_AI_MODELS,
+  WORKERS_AI_IMAGE_MODELS,
+} from "../src/shared-index";
+
+describe("/generate slash command regex", () => {
+  // Mirror of the client-side regex in public/js/dodo-chat.js. Duplicated as a
+  // plain literal so a regex change there forces a change here too.
+  const SLASH_REGEX = /^\/generate\s+([\s\S]+)$/i;
+
+  it("matches a basic prompt", () => {
+    const m = "/generate a cyberpunk cat".match(SLASH_REGEX);
+    expect(m?.[1]).toBe("a cyberpunk cat");
+  });
+
+  it("is case-insensitive", () => {
+    const m = "/GENERATE a dog".match(SLASH_REGEX);
+    expect(m?.[1]).toBe("a dog");
+  });
+
+  it("preserves multi-line prompts", () => {
+    const m = "/generate line one\nline two\nline three".match(SLASH_REGEX);
+    expect(m?.[1]).toBe("line one\nline two\nline three");
+  });
+
+  it("does not match without a prompt segment", () => {
+    // Missing whitespace + prompt entirely
+    expect("/generate".match(SLASH_REGEX)).toBeNull();
+    // `/generate ` has trailing whitespace but nothing else, so `[\s\S]+` has
+    // nothing to capture and the match fails.
+    expect("/generate ".match(SLASH_REGEX)).toBeNull();
+  });
+
+  it("matches whitespace-only prompts but the client trims them out", () => {
+    // The regex itself matches because `\s+([\s\S]+)` will greedily capture
+    // at least one char after the first whitespace run — including more
+    // whitespace. The client-side `.trim()` + empty check is what surfaces
+    // the "Add a prompt after /generate" toast. Guard the shape here so the
+    // regex stays aligned with the client-side trimming contract.
+    const m = "/generate   ".match(SLASH_REGEX);
+    expect(m).not.toBeNull();
+    expect(m![1].trim()).toBe("");
+  });
+
+  it("does not match concatenated words", () => {
+    // `/generatefoo` shouldn't trigger — we require whitespace separator.
+    expect("/generatefoo".match(SLASH_REGEX)).toBeNull();
+  });
+
+  it("does not match messages where /generate is not at the start", () => {
+    expect("please /generate a cat".match(SLASH_REGEX)).toBeNull();
+  });
+
+  it("strips leading whitespace from the prompt", () => {
+    // The capturing group starts after `\s+`, so leading whitespace is already
+    // consumed — the first whitespace character after /generate is the delimiter.
+    const m = "/generate   a tidy prompt".match(SLASH_REGEX);
+    expect(m?.[1]).toBe("a tidy prompt");
+  });
+});
+
+describe("FLUX prompt length enforcement", () => {
+  it("FLUX_MAX_PROMPT_LENGTH matches the Workers AI model schema", () => {
+    // Per https://developers.cloudflare.com/workers-ai/models/flux-1-schnell/
+    // the `prompt` field has `maxLength: 2048`. If Cloudflare lifts the cap we
+    // should update this constant — the test exists to flag that drift.
+    expect(FLUX_MAX_PROMPT_LENGTH).toBe(2048);
+  });
+
+  it("FLUX constants are exported for handler + test parity", () => {
+    expect(FLUX_IMAGE_MODEL).toBe("@cf/black-forest-labs/flux-1-schnell");
+    expect(FLUX_IMAGE_MEDIA_TYPE).toBe("image/jpeg");
+  });
+});
+
+describe("Workers AI model catalog", () => {
+  it("does not list FLUX in the chat model picker", () => {
+    // FLUX is text-to-image — surfacing it in the chat model picker would let
+    // users set it as their default and brick every subsequent prompt. Keep
+    // image models strictly separate.
+    const chatIds = WORKERS_AI_MODELS.map((m) => m.id);
+    expect(chatIds).not.toContain("@cf/black-forest-labs/flux-1-schnell");
+  });
+
+  it("lists FLUX in the image-model catalog", () => {
+    const imageIds = WORKERS_AI_IMAGE_MODELS.map((m) => m.id);
+    expect(imageIds).toContain("@cf/black-forest-labs/flux-1-schnell");
+  });
+
+  it("image models have kind=text-to-image", () => {
+    for (const m of WORKERS_AI_IMAGE_MODELS) {
+      expect(m.kind).toBe("text-to-image");
+    }
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -63,6 +63,9 @@
   "assets": {
     "directory": "./public"
   },
+  "ai": {
+    "binding": "AI"
+  },
   "secrets": {
     "required": ["ADMIN_EMAIL"]
   },


### PR DESCRIPTION
## Summary

- Adds `/generate <prompt>` slash command that generates images via Workers AI FLUX-1-schnell and renders them inline
- New `POST /session/:id/generate` endpoint bypasses the LLM chat path entirely
- Images are uploaded to R2 under `attachments/` and delivered via existing `message_attachments` SSE event

## Why

A previous session (`65c3019e`) showed me asking an LLM (GPT-5.4) to generate a steampunk Cloudflare logo — it just offered prompt-writing advice instead. Dodo couldn't actually *make* images.

Workers AI has FLUX-1-schnell available as `@cf/black-forest-labs/flux-1-schnell` and the UI already knows how to render attachments. This PR wires the two together.

## What changed

- **`wrangler.jsonc`** — add `ai: { binding: "AI" }`
- **`src/types.ts`** — add `AI: Ai` to the `Env` interface
- **`src/shared-index.ts`** — add FLUX-1-schnell to `WORKERS_AI_MODELS` catalog
- **`src/index.ts`** — add `POST /session/:id/generate` (rate-limited 30/hr per user)
- **`src/coding-agent.ts`** — add `handleGenerate()`:
  - Persists user message to Think session
  - Calls `env.AI.run("@cf/black-forest-labs/flux-1-schnell", { prompt })`
  - Uploads base64 JPEG to R2 via existing `uploadAttachment()`
  - Emits `message` + `message_attachments` SSE events
- **`public/js/dodo-chat.js`** — detect `/generate <prompt>` in `sendMessage()` and route to new endpoint

## Test plan

- ✅ `npx tsc --noEmit` passes
- ✅ `npx vitest run` — all 382 tests pass
- [ ] Manual: type `/generate a cyberpunk cat` in a Dodo session, verify image renders inline

## Notes

- FLUX-1-schnell returns base64 JPEG in `response.image` — we upload that to R2 directly rather than inlining the data URL
- The user sees a minimal assistant bubble with the image; no LLM narration is involved
- Rate limit is 30/hr per user (half of chat prompt limit) to stay conservative on Workers AI costs

beep-boop-🤖