### PR TITLE
Server-side /generate routing + UI autocomplete + MCP tool

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -194,9 +194,19 @@
     @keyframes cursor-blink{0%,100%{opacity:1}50%{opacity:0}}
 
     /* === Input bar — textarea for multi-line === */
-    .input-bar{display:flex;gap:8px;padding:12px 16px;border-top:1px solid var(--line);background:var(--base);align-items:flex-end}
+    .input-bar{display:flex;gap:8px;padding:12px 16px;border-top:1px solid var(--line);background:var(--base);align-items:flex-end;position:relative}
     .input-bar textarea{flex:1;min-height:40px;max-height:160px;resize:none;padding:10px 12px;line-height:1.4;font-family:inherit;font-size:13.5px}
     .input-bar .input-actions{display:flex;gap:4px;flex-shrink:0;align-items:flex-end}
+
+    /* === Slash command autocomplete === */
+    .slash-menu{position:absolute;bottom:calc(100% + 4px);left:16px;right:16px;max-width:520px;background:var(--base);border:1px solid var(--line);border-radius:8px;box-shadow:0 6px 24px rgba(0,0,0,.18);overflow:hidden;z-index:50}
+    .slash-menu[hidden]{display:none}
+    .slash-menu-item{display:flex;flex-direction:column;gap:2px;padding:8px 12px;cursor:pointer;border-bottom:1px solid var(--line)}
+    .slash-menu-item:last-child{border-bottom:none}
+    .slash-menu-item.active,.slash-menu-item:hover{background:var(--panel)}
+    .slash-menu-item .cmd{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;color:var(--brand);font-weight:500}
+    .slash-menu-item .desc{font-size:11.5px;color:var(--muted);line-height:1.3}
+    .slash-menu-hint{padding:6px 12px;font-size:10.5px;color:var(--muted);background:var(--panel);border-top:1px solid var(--line)}
 
     /* === Send / Abort toggle button === */
     #send-btn{width:40px;height:40px;min-height:40px;padding:0;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-size:18px;transition:background .2s,border-color .2s,color .2s,transform .1s}
@@ -618,7 +628,8 @@
       <div id="typing-indicator" class="typing-indicator" style="display:none"></div>
       <div id="image-preview-bar" class="image-preview-bar"></div>
       <div class="input-bar">
-        <textarea id="msg-input" rows="1" placeholder="Ask Dodo to build something..." onkeydown="handleInputKeydown(event)" oninput="autoResizeInput(this);sendTypingStart()" onpaste="handleImagePaste(event)" onfocus="setTimeout(()=>this.scrollIntoView({block:'nearest',behavior:'smooth'}),300)" aria-label="Message input"></textarea>
+        <div id="slash-menu" class="slash-menu" role="listbox" aria-label="Slash command suggestions" hidden></div>
+        <textarea id="msg-input" rows="1" placeholder="Ask Dodo to build something..." onkeydown="handleInputKeydown(event)" oninput="autoResizeInput(this);sendTypingStart();updateSlashMenu()" onpaste="handleImagePaste(event)" onfocus="setTimeout(()=>this.scrollIntoView({block:'nearest',behavior:'smooth'}),300)" onblur="setTimeout(hideSlashMenu,150)" aria-label="Message input" aria-autocomplete="list" aria-controls="slash-menu"></textarea>
         <div class="input-actions">
           <input type="file" id="image-file-input" accept="image/png,image/jpeg,image/gif,image/webp" multiple style="display:none" onchange="handleFileSelect(this)"/>
           <button class="ghost" onclick="$('image-file-input').click()" title="Attach image" aria-label="Attach image"><i class="ph ph-paperclip"></i></button>

--- a/public/js/dodo-core.js
+++ b/public/js/dodo-core.js
@@ -111,11 +111,106 @@ applyTheme(getTheme());
 
 // === Multi-line input handling ===
 function handleInputKeydown(event){
+  // Slash command menu captures Arrow/Enter/Escape when it's visible — when
+  // the user is picking a command we don't want Enter to send an incomplete
+  // message.
+  if(handleSlashMenuKeydown(event))return;
   if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendMessage()}
 }
 function autoResizeInput(el){
   el.style.height='auto';
   el.style.height=Math.min(el.scrollHeight,160)+'px';
+}
+
+// === Slash command autocomplete ===
+// Keep definitions in one list so adding a new command means one edit here.
+const SLASH_COMMANDS=[
+  {cmd:"/generate",desc:"Generate an image with FLUX-1-schnell",template:"/generate "},
+];
+let slashMenuActive=-1;
+let slashMenuVisible=false;
+
+function updateSlashMenu(){
+  const input=$("msg-input");
+  const menu=$("slash-menu");
+  if(!input||!menu)return;
+  const value=input.value;
+  // Only surface suggestions when the textarea starts with `/` and the user
+  // hasn't yet typed the space that ends the command token. Matching
+  // anywhere else would pop the menu mid-sentence which is just noise.
+  const match=value.match(/^(\/\w*)$/);
+  if(!match){hideSlashMenu();return}
+  const typed=match[1].toLowerCase();
+  const matches=SLASH_COMMANDS.filter(c=>c.cmd.startsWith(typed));
+  if(!matches.length){hideSlashMenu();return}
+  slashMenuActive=0;
+  renderSlashMenu(matches);
+}
+
+function renderSlashMenu(matches){
+  const menu=$("slash-menu");
+  menu.innerHTML=matches.map((c,i)=>{
+    const active=i===slashMenuActive?" active":"";
+    return `<div class="slash-menu-item${active}" role="option" data-cmd="${esc(c.cmd)}" onmousedown="event.preventDefault();pickSlashCommand('${esc(c.cmd)}')"><span class="cmd">${esc(c.cmd)}</span><span class="desc">${esc(c.desc)}</span></div>`;
+  }).join("")+`<div class="slash-menu-hint">Tab or Enter to complete \u00b7 Esc to dismiss</div>`;
+  menu.hidden=false;
+  slashMenuVisible=true;
+  menu._matches=matches;
+}
+
+function hideSlashMenu(){
+  const menu=$("slash-menu");
+  if(!menu)return;
+  menu.hidden=true;
+  menu.innerHTML="";
+  menu._matches=null;
+  slashMenuVisible=false;
+  slashMenuActive=-1;
+}
+
+function pickSlashCommand(cmd){
+  const input=$("msg-input");
+  const command=SLASH_COMMANDS.find(c=>c.cmd===cmd);
+  input.value=command?.template||(cmd+" ");
+  autoResizeInput(input);
+  hideSlashMenu();
+  input.focus();
+  // Place the caret at the end so the user can immediately type the prompt
+  const end=input.value.length;
+  input.setSelectionRange(end,end);
+}
+
+// Return true when the keystroke was absorbed by the slash menu so the
+// caller skips its normal handling (e.g. Enter-to-send).
+function handleSlashMenuKeydown(event){
+  if(!slashMenuVisible)return false;
+  const menu=$("slash-menu");
+  const matches=menu?._matches||[];
+  if(!matches.length)return false;
+  if(event.key==="ArrowDown"){
+    event.preventDefault();
+    slashMenuActive=(slashMenuActive+1)%matches.length;
+    renderSlashMenu(matches);
+    return true;
+  }
+  if(event.key==="ArrowUp"){
+    event.preventDefault();
+    slashMenuActive=(slashMenuActive-1+matches.length)%matches.length;
+    renderSlashMenu(matches);
+    return true;
+  }
+  if(event.key==="Enter"||event.key==="Tab"){
+    event.preventDefault();
+    const picked=matches[slashMenuActive]||matches[0];
+    if(picked)pickSlashCommand(picked.cmd);
+    return true;
+  }
+  if(event.key==="Escape"){
+    event.preventDefault();
+    hideSlashMenu();
+    return true;
+  }
+  return false;
 }
 
 // === API helpers ===

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -33,7 +33,7 @@ import {
 } from "./think-adapter";
 import type { SnapshotV2 } from "./think-adapter";
 import type { AppConfig, ChatMessageRecord, CronJobRecord, Env, PromptRecord, SessionEvent, SessionSnapshot, SessionState, WorkspaceEntry } from "./types";
-import { FALLBACK_MODELS, WORKERS_AI_MODELS, FLUX_IMAGE_MODEL, FLUX_IMAGE_MEDIA_TYPE, FLUX_MAX_PROMPT_LENGTH } from "./shared-index";
+import { FALLBACK_MODELS, WORKERS_AI_MODELS, FLUX_IMAGE_MODEL, FLUX_IMAGE_MEDIA_TYPE, FLUX_MAX_PROMPT_LENGTH, extractGeneratePrompt } from "./shared-index";
 
 /**
  * Context window sizes (in tokens) by model ID. Used for token budget enforcement.
@@ -2859,6 +2859,21 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.mcpDepth = parseInt(request.headers.get("x-dodo-mcp-depth") ?? "0", 10) || 0;
     this.ensureMetadata(sessionId, ownerEmail);
 
+    // Server-side slash command routing so /generate works from every entry
+    // point (browser UI, MCP tools, webhooks) — not just the client JS. We do
+    // this before the active-prompt check because `runImageGeneration` has its
+    // own 409 handling for that case.
+    const imagePrompt = extractGeneratePrompt(input.content);
+    if (imagePrompt) {
+      this.ensureThinkConfig(request);
+      return this.runImageGeneration({
+        prompt: imagePrompt,
+        sessionId,
+        authorEmail,
+        ownerEmail,
+      });
+    }
+
     // handleMessage is synchronous — callers (MCP, external integrations) expect the
     // assistant response in the HTTP reply. Queuing would lose the response. Keep 409.
     if (this.readMetadata("active_prompt_id")) {
@@ -2919,6 +2934,20 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.ensureMetadata(sessionId, ownerEmail);
     this.ensureThinkConfig(request);
 
+    // Server-side slash routing — /generate works the same whether it comes
+    // from the browser UI, an MCP `send_prompt` call, a webhook, etc. Image
+    // uploads alongside /generate are ignored (FLUX-1-schnell is text-to-image
+    // only; multi-reference inputs are FLUX.2).
+    const imagePrompt = extractGeneratePrompt(input.content);
+    if (imagePrompt) {
+      return this.runImageGeneration({
+        prompt: imagePrompt,
+        sessionId,
+        authorEmail,
+        ownerEmail,
+      });
+    }
+
     // If a prompt is already running, queue this one
     if (this.readMetadata("active_prompt_id")) {
       return this.enqueuePrompt(input.content, authorEmail);
@@ -2955,6 +2984,27 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const ownerEmail = request.headers.get("x-owner-email");
     this.ensureMetadata(sessionId, ownerEmail);
     this.ensureThinkConfig(request);
+    return this.runImageGeneration({
+      prompt: input.content,
+      sessionId,
+      authorEmail,
+      ownerEmail,
+    });
+  }
+
+  /** Shared image-generation core. Invoked by `handleGenerate` (dedicated
+   *  endpoint) and by `handleMessage`/`handlePrompt` when they detect a
+   *  `/generate` slash command in the chat content. Returns a Response so
+   *  callers can bubble errors and status codes without double-wrapping. */
+  private async runImageGeneration(opts: {
+    prompt: string;
+    sessionId: string;
+    authorEmail: string | null;
+    ownerEmail: string | null;
+  }): Promise<Response> {
+    if (opts.prompt.length > FLUX_MAX_PROMPT_LENGTH) {
+      return Response.json({ error: `Prompt exceeds ${FLUX_MAX_PROMPT_LENGTH} characters` }, { status: 400 });
+    }
 
     const thinkSessionId = this.getCurrentSessionId();
     if (!thinkSessionId) {
@@ -2970,23 +3020,23 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     }
 
     const promptId = crypto.randomUUID();
-    const title = this.readMetadata("title") ?? (input.content.length > 72 ? input.content.slice(0, 72) + "…" : input.content);
+    const title = this.readMetadata("title") ?? (opts.prompt.length > 72 ? opts.prompt.slice(0, 72) + "…" : opts.prompt);
 
     this.writeMetadata("title", title);
     this.writeMetadata("active_prompt_id", promptId);
     this.writeMetadata("status", "running");
-    this.insertPrompt(promptId, input.content, "queued", authorEmail);
+    this.insertPrompt(promptId, opts.prompt, "queued", opts.authorEmail);
     await this.syncSessionIndex({ status: "running", title });
     this.emitEvent({ data: this.readSessionDetails(), type: "state" });
 
     try {
       // 1. Persist user prompt message
-      const userMsgId = this.persistGenerateUserMessage(thinkSessionId, input.content, authorEmail);
+      const userMsgId = this.persistGenerateUserMessage(thinkSessionId, opts.prompt, opts.authorEmail);
 
       // 2. Generate image via Workers AI. Pass a random seed so repeat
       //    invocations of the same prompt don't collapse to identical output.
       const raw = await this.env.AI.run(FLUX_IMAGE_MODEL, {
-        prompt: input.content,
+        prompt: opts.prompt,
         seed: Math.floor(Math.random() * 1_000_000),
       });
       // Defensive parsing — type assertions would silently break if the
@@ -2999,10 +3049,10 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       // 3. Persist assistant message with the generated image
       const assistantResult = await this.persistGeneratedImageMessage({
         thinkSessionId,
-        sessionId,
-        prompt: input.content,
+        sessionId: opts.sessionId,
+        prompt: opts.prompt,
         imageData,
-        ownerEmail: ownerEmail ?? undefined,
+        ownerEmail: opts.ownerEmail ?? undefined,
       });
 
       await this.finishPrompt(promptId, { resultMessageId: assistantResult.messageId, status: "completed" });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -830,6 +830,17 @@ export function createDodoMcpServer(env: Env, depth = 0): McpServer {
     }),
   );
 
+  server.tool("generate_image", "Generate an image with Workers AI FLUX-1-schnell and post it to the session. Bypasses the chat LLM — routes straight to the image model.", {
+    sessionId: z.string().describe("Session ID"),
+    prompt: z.string().min(1).max(2048).describe("Text prompt describing the image (1-2048 chars)"),
+  }, async ({ sessionId, prompt }) =>
+    jsonFetch(env, "agent", "/generate", {
+      sessionId,
+      depth,
+      init: { body: JSON.stringify({ content: prompt }), headers: { "content-type": "application/json" }, method: "POST" },
+    }),
+  );
+
   server.tool("abort_prompt", "Abort a running async prompt", {
     sessionId: z.string().describe("Session ID"),
   }, async ({ sessionId }) =>

--- a/src/shared-index.ts
+++ b/src/shared-index.ts
@@ -47,6 +47,22 @@ export const FLUX_IMAGE_MEDIA_TYPE = "image/jpeg";
 /** FLUX-1-schnell API limit per the model schema (developers.cloudflare.com/workers-ai/models/flux-1-schnell). */
 export const FLUX_MAX_PROMPT_LENGTH = 2048;
 
+/** Canonical /generate slash command regex. Shared by the server entry points
+ *  (handleMessage/handlePrompt) and the browser client so all paths agree on
+ *  what qualifies as an image-generation request. `[\s\S]+` (not `.+`) preserves
+ *  multi-line prompts — dot-any-char would clip at the first newline. */
+export const GENERATE_SLASH_REGEX = /^\/generate\s+([\s\S]+)$/i;
+
+/** Extract the image prompt from a message if it's a /generate slash command.
+ *  Returns null for normal messages. The returned prompt is trimmed; callers
+ *  should reject empty strings (whitespace-only user input). */
+export function extractGeneratePrompt(content: string): string | null {
+  const match = content.match(GENERATE_SLASH_REGEX);
+  if (!match) return null;
+  const prompt = match[1].trim();
+  return prompt.length > 0 ? prompt : null;
+}
+
 /** Provider prefixes the opencode gateway can actually route.
  *  The models.dev provider TOMLs often fall back to `anthropic/` for non-Anthropic models
  *  (kimi, glm, qwen, mimo, minimax, etc.), which the gateway then forwards to Anthropic

--- a/test/generate-unit.test.ts
+++ b/test/generate-unit.test.ts
@@ -18,12 +18,14 @@ import {
   FLUX_MAX_PROMPT_LENGTH,
   WORKERS_AI_MODELS,
   WORKERS_AI_IMAGE_MODELS,
+  extractGeneratePrompt,
+  GENERATE_SLASH_REGEX,
 } from "../src/shared-index";
 
 describe("/generate slash command regex", () => {
-  // Mirror of the client-side regex in public/js/dodo-chat.js. Duplicated as a
-  // plain literal so a regex change there forces a change here too.
-  const SLASH_REGEX = /^\/generate\s+([\s\S]+)$/i;
+  // The canonical regex ships from shared-index so server handlers and the
+  // browser client use the same matcher. Guard the shape here.
+  const SLASH_REGEX = GENERATE_SLASH_REGEX;
 
   it("matches a basic prompt", () => {
     const m = "/generate a cyberpunk cat".match(SLASH_REGEX);
@@ -108,5 +110,36 @@ describe("Workers AI model catalog", () => {
     for (const m of WORKERS_AI_IMAGE_MODELS) {
       expect(m.kind).toBe("text-to-image");
     }
+  });
+});
+
+describe("extractGeneratePrompt", () => {
+  it("returns the prompt for a valid /generate message", () => {
+    expect(extractGeneratePrompt("/generate a cat")).toBe("a cat");
+  });
+
+  it("returns null for normal chat messages", () => {
+    expect(extractGeneratePrompt("hello there")).toBeNull();
+    expect(extractGeneratePrompt("let's /generate something later")).toBeNull();
+  });
+
+  it("returns null for /generate with only whitespace after", () => {
+    // Guards against routing empty image requests to FLUX.
+    expect(extractGeneratePrompt("/generate")).toBeNull();
+    expect(extractGeneratePrompt("/generate ")).toBeNull();
+    expect(extractGeneratePrompt("/generate   \n  ")).toBeNull();
+  });
+
+  it("trims surrounding whitespace from the prompt", () => {
+    expect(extractGeneratePrompt("/generate   neon cat   ")).toBe("neon cat");
+  });
+
+  it("preserves multi-line prompts", () => {
+    expect(extractGeneratePrompt("/generate line one\nline two")).toBe("line one\nline two");
+  });
+
+  it("is case-insensitive on the command keyword", () => {
+    expect(extractGeneratePrompt("/GENERATE a dog")).toBe("a dog");
+    expect(extractGeneratePrompt("/Generate a dog")).toBe("a dog");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #42. Makes /generate actually work from every entry point, adds slash-command autocomplete to the UI, and exposes a `generate_image` MCP tool.

## Why

After #42 shipped, I tried `/generate a cyberpunk cat` via the Dodo MCP `send_message` tool and got GPT-5.4 offering to write a prompt for me. Turned out the slash command only worked in the browser — the server was happily passing `/generate ...` through to the LLM. So I fixed that.

## What changed

**Server-side slash routing**
- `handleMessage` and `handlePrompt` now detect `/generate` content and delegate to `runImageGeneration` before touching the LLM.
- Works from the browser UI, MCP tools (`send_message`, `send_prompt`), and any future HTTP clients.
- Behaviour matches the dedicated `/generate` endpoint — same 409 on concurrent prompts, same 400 on prompt >2048 chars, same `message_attachments` SSE event.

**UI autocomplete**
- Typing `/` in the chat input pops a suggestions menu above the textarea.
- Arrow keys navigate, Enter/Tab completes, Escape dismisses.
- Mouse click also works (mousedown is trapped so the textarea doesn't lose focus).
- Driven off a single `SLASH_COMMANDS` array — adding a new command = one edit.

**New MCP tool**
- `generate_image(sessionId, prompt)` calls `/generate` directly. Lets LLM agents invoke FLUX from conversations without going through the chat model.

**Refactor**
- Extract `runImageGeneration(...)` core from `handleGenerate` so the endpoint handler and the slash-routed handlers share a single image-generation code path.
- New `extractGeneratePrompt()` helper + `GENERATE_SLASH_REGEX` constant in `shared-index.ts`. Browser and server now reference the same regex.

**Tests**
- 6 new unit tests for `extractGeneratePrompt` (happy path, null on non-slash messages, whitespace handling, multi-line prompts, case-insensitive keyword)
- Existing slash-regex tests now reference the canonical shared export
- All 401 tests pass (up from 395 on #42)

## Test plan

- ✅ `npx tsc --noEmit` passes
- ✅ `npx vitest run` — all 401 tests pass
- [ ] Manual: type `/` in the chat UI, verify autocomplete menu appears
- [ ] Manual: call the `generate_image` MCP tool and verify FLUX responds

## Notes

- The client-side `/generate` intercept in `dodo-chat.js` is kept on purpose — it routes straight to the synchronous `/generate` endpoint for snappier UX than going through `/prompt` (which would queue).
- Image uploads alongside a `/generate` prompt are ignored. FLUX-1-schnell is text-to-image only; multi-reference inputs are a FLUX.2 feature.

beep-boop-🤖