### PR TITLE
docs: /generate command + image generation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Dodo exposes two MCP endpoints. Use the one that fits your use case:
 
 | Endpoint | Tools | Best for |
 |----------|-------|----------|
-| `/mcp` | 47 | **Orchestrators** -- full control over sessions, tasks, git, memory, dispatch |
+| `/mcp` | 48 | **Orchestrators** -- full control over sessions, tasks, git, memory, dispatch |
 | `/mcp/codemode` | 2 | **Coding agents** -- just `search` + `execute` (~1k tokens context) |
 
 **Example config** (works with OpenCode, Claude Code, Cursor, or any MCP client):
@@ -206,13 +206,31 @@ Per-user key-value store with text search, persistent across sessions. Your agen
 
 Headless Chrome via Cloudflare Browser Rendering. Full CDP (Chrome DevTools Protocol) access through two code-mode tools: `browser_search` (query the CDP spec) and `browser_execute` (run CDP commands). The agent can navigate pages, read documentation, fill forms, and scrape data. Desktop viewport + full-page capture work out of the box. Screenshots captured via `Page.captureScreenshot` render inline in the chat and persist across reloads -- see Attachments below.
 
+### Image generation (/generate)
+
+Type `/generate a cyberpunk cat` in any chat to generate an image with Workers AI FLUX-1-schnell. Bypasses the chat LLM entirely — the image comes back in a few seconds and renders inline.
+
+- **Autocomplete** — start typing `/` in the input box to see the command menu.
+- **Routes everywhere** — works from the browser UI, MCP (`generate_image` tool, or any message containing `/generate` via `send_message`/`send_prompt`), and the dedicated `POST /session/:id/generate` endpoint.
+- **Limits** — 2048-char prompt cap (FLUX schema), 30 images/hour + 100/day per user, concurrent-prompt guard (returns 409 if another prompt is running).
+- **Requires** — the `AI` binding in `wrangler.jsonc`:
+
+  ```jsonc
+  "ai": {
+    "binding": "AI"
+  }
+  ```
+
+  Workers AI is enabled on every paid Workers plan; the free tier has a daily neuron quota.
+
 ### Attachments (images in chat)
 
-Images surface in the chat from three sources and flow through the same R2-backed pipeline:
+Images surface in the chat from four sources and flow through the same R2-backed pipeline:
 
 - **User uploads** -- Paste an image or click the paperclip to send a screenshot to a multimodal model (Claude, Gemini, GPT-4o, Gemma). Limits: 5 images per message, 3MB raw per image, PNG/JPEG/GIF/WebP.
 - **Browser tool screenshots** -- `browser_execute` extracts screenshots from the CDP result, stashes them in R2, and returns a short text summary to the model (so base64 doesn't burn context). Images render inline on the tool-result bubble.
 - **Model-generated images** -- Responses from image-generating models (e.g. Gemini imagen, Gemma vision) are captured during the stream, uploaded to R2, and rendered on the assistant bubble.
+- **`/generate` slash command** -- Type `/generate <prompt>` in any chat to bypass the LLM and hit Workers AI FLUX-1-schnell directly. Image appears inline in a few seconds. Works from the browser UI (with autocomplete — type `/` to see the menu), the MCP `generate_image` tool, or any chat message containing `/generate` (server-side slash routing catches it). Rate-limited to 30 images/hour and 100/day per user; prompts capped at 2048 chars per the FLUX schema. Requires the `AI` binding in `wrangler.jsonc`.
 
 **Storage:** Attachments live in the `dodo-workspaces` R2 bucket under the `attachments/{sessionId}/{messageId}/` prefix. Run `scripts/setup-attachment-lifecycle.sh` once per account to install the **30-day auto-expiry** lifecycle rule (lifecycle rules aren't yet configurable via `wrangler.jsonc`). Access is ACL-gated via the existing `/session/:id/*` ownership middleware — if you can't read the session, you can't read its attachments.
 

--- a/public/docs.html
+++ b/public/docs.html
@@ -54,6 +54,7 @@
         <li><a href="#architecture">Architecture</a></li>
         <li><a href="#sessions">Sessions</a></li>
         <li><a href="#chat">Chat &amp; Streaming</a></li>
+        <li><a href="#image-gen">Image Generation</a></li>
         <li><a href="#files">Workspace Files</a></li>
         <li><a href="#git">Git</a></li>
         <li><a href="#kanban">Task Board (Kanban)</a></li>
@@ -208,9 +209,30 @@
       <li><strong>Abort</strong> — cancels a running prompt immediately.</li>
       <li><strong>Streaming renderer</strong> — text appears immediately as deltas arrive, then Dodo upgrades it into full markdown a few times per second so long messages stay responsive.</li>
       <li><strong>Markdown</strong> — assistant messages render GitHub-flavored markdown. Each code block has a copy button.</li>
+      <li><strong>Slash commands</strong> — type <code>/</code> in the input to see available commands. <kbd>↑</kbd>/<kbd>↓</kbd> to navigate, <kbd>Tab</kbd> or <kbd>Enter</kbd> to complete, <kbd>Esc</kbd> to dismiss. See <a href="#image-gen">Image generation</a>.</li>
       <li><strong>Presence</strong> — when multiple users share a session, you see avatar dots in the header and typing indicators.</li>
       <li><strong>Build marker</strong> — the header shows the deployed build hash when available, so you can confirm which revision the UI is running.</li>
     </ul>
+
+    <!-- ─── Image generation ─── -->
+    <h2 id="image-gen">Image Generation</h2>
+    <p>Dodo includes a dedicated image-generation path that bypasses the chat LLM. Type <code>/generate &lt;prompt&gt;</code> in any session to get a FLUX-1-schnell image rendered inline in a few seconds. Routes through the same R2-backed attachment pipeline as other images (see <a href="#api">Attachments</a>).</p>
+    <table>
+      <tr><th>Entry point</th><th>How to trigger</th></tr>
+      <tr><td><strong>Browser UI</strong></td><td>Type <code>/</code> for autocomplete, pick <code>/generate</code>, type a prompt, hit <kbd>Enter</kbd>.</td></tr>
+      <tr><td><strong>MCP tool</strong></td><td>Call <code>generate_image(sessionId, prompt)</code> directly. See <a href="#mcp-client">Connecting via MCP</a>.</td></tr>
+      <tr><td><strong>MCP message</strong></td><td>Any <code>send_message</code> or <code>send_prompt</code> call whose content starts with <code>/generate </code> is routed to FLUX by the server.</td></tr>
+      <tr><td><strong>HTTP endpoint</strong></td><td><code>POST /session/:id/generate</code> with <code>{ content: "..." }</code>. Returns the assistant message synchronously.</td></tr>
+    </table>
+    <h3>Limits and requirements</h3>
+    <ul>
+      <li><strong>Model</strong> — <code>@cf/black-forest-labs/flux-1-schnell</code> (Workers AI).</li>
+      <li><strong>Prompt length</strong> — 2048 characters max (FLUX schema limit).</li>
+      <li><strong>Rate limits</strong> — 30 images per hour and 100 per day per user.</li>
+      <li><strong>Concurrency</strong> — returns 409 if another prompt is already running on the session.</li>
+      <li><strong>Binding</strong> — requires <code>"ai": { "binding": "AI" }</code> in <code>wrangler.jsonc</code>. The AI binding is enabled on all paid Workers plans; the free tier has a daily neuron cap.</li>
+    </ul>
+    <div class="callout"><p>FLUX-1-schnell does not appear in the chat model picker — it's text-to-image only and would break a chat session if set as the default. Use <code>/generate</code> instead.</p></div>
 
     <!-- ─── Files ─── -->
     <h2 id="files">Workspace Files</h2>
@@ -445,7 +467,7 @@
       <tr><td>*</td><td><code>/api/secrets</code></td><td>Encrypted secrets CRUD</td></tr>
       <tr><td>*</td><td><code>/api/mcp-configs</code></td><td>Integration (MCP server) CRUD</td></tr>
       <tr><td>*</td><td><code>/api/passkey</code></td><td>Init, change passkey</td></tr>
-      <tr><td>ALL</td><td><code>/mcp</code></td><td>MCP server endpoint (Bearer auth) — 46 tools for orchestration</td></tr>
+      <tr><td>ALL</td><td><code>/mcp</code></td><td>MCP server endpoint (Bearer auth) — 48 tools for orchestration</td></tr>
       <tr><td>ALL</td><td><code>/mcp/codemode</code></td><td>Code-mode MCP endpoint — 2 tools (<code>search</code> + <code>execute</code>), ~1k tokens context. Ideal for coding agents.</td></tr>
     </table>
 
@@ -460,6 +482,7 @@
       <tr><td>POST</td><td><code>/session/:id/fork</code></td><td>Fork session (copy files + messages)</td></tr>
       <tr><td>POST</td><td><code>/session/:id/message</code></td><td>Sync message (streaming)</td></tr>
       <tr><td>POST</td><td><code>/session/:id/prompt</code></td><td>Async prompt (fiber-backed)</td></tr>
+      <tr><td>POST</td><td><code>/session/:id/generate</code></td><td>Generate an image with FLUX-1-schnell. Bypasses the chat LLM. See <a href="#image-gen">Image Generation</a>.</td></tr>
       <tr><td>POST</td><td><code>/session/:id/abort</code></td><td>Abort running prompt</td></tr>
       <tr><td>GET</td><td><code>/session/:id/events</code></td><td>SSE stream (text_delta, message, state, tool_call, ...)</td></tr>
       <tr><td>GET</td><td><code>/session/:id/messages</code></td><td>Message history</td></tr>
@@ -543,8 +566,9 @@
     <h4>Chat</h4>
     <table>
       <tr><th>Tool</th><th>Description</th></tr>
-      <tr><td><code>send_message</code></td><td>Synchronous message (waits for response)</td></tr>
-      <tr><td><code>send_prompt</code></td><td>Async prompt (returns immediately, runs in background)</td></tr>
+      <tr><td><code>send_message</code></td><td>Synchronous message (waits for response). A content starting with <code>/generate </code> is auto-routed to FLUX.</td></tr>
+      <tr><td><code>send_prompt</code></td><td>Async prompt (returns immediately, runs in background). A content starting with <code>/generate </code> is auto-routed to FLUX.</td></tr>
+      <tr><td><code>generate_image</code></td><td>Generate a FLUX-1-schnell image directly. Takes <code>sessionId</code> + <code>prompt</code> (1-2048 chars). See <a href="#image-gen">Image Generation</a>.</td></tr>
       <tr><td><code>abort_prompt</code></td><td>Abort a running prompt</td></tr>
       <tr><td><code>get_messages</code></td><td>Get message history</td></tr>
       <tr><td><code>get_prompts</code></td><td>Get prompt history</td></tr>

--- a/public/howto.html
+++ b/public/howto.html
@@ -52,6 +52,7 @@
       <ul>
         <li><a href="#first-session">Create Your First Session</a></li>
         <li><a href="#clone-repo">Clone a GitHub Repo</a></li>
+        <li><a href="#generate-image">Generate an Image</a></li>
         <li><a href="#fork-session">Fork a Session for Experiments</a></li>
         <li><a href="#schedule-task">Schedule a Recurring Task</a></li>
         <li><a href="#connect-mcp">Connect an MCP Server</a></li>
@@ -80,6 +81,17 @@
 </code></pre>
     <p>Once the clone finishes, ask the agent to inspect files, run tests, or start making changes inside that workspace.</p>
     <div class="callout"><p>Warning: Set the token first if you plan to clone or push private repositories. Missing credentials usually show up as git auth errors.</p></div>
+
+    <h2 id="generate-image">Generate an Image</h2>
+    <h3>Create pictures without leaving the chat</h3>
+    <p>Type <code>/</code> in the chat input to open the slash-command menu, pick <code>/generate</code>, then describe the image you want. Press <kbd>Enter</kbd>. Dodo sends the prompt to Workers AI FLUX-1-schnell and renders the image inline in a few seconds.</p>
+    <pre><code>/generate a cyberpunk cat wearing sunglasses, neon city background
+</code></pre>
+    <p>No LLM is involved — the slash command routes straight to the image model. That means the image is cheap, fast, and doesn't consume your chat model's context window.</p>
+    <p>From an MCP client, call <code>generate_image</code> directly with a session ID and a prompt. Sending a regular chat message whose content starts with <code>/generate</code> works too; the server detects and reroutes it.</p>
+    <pre><code>generate_image({ sessionId: "session_123", prompt: "a steampunk dodo bird" })
+</code></pre>
+    <div class="callout"><p>Limits: prompts up to 2048 characters, 30 images per hour and 100 per day per user. Requires the <code>AI</code> binding in <code>wrangler.jsonc</code> — paid Workers plans include it.</p></div>
 
     <h2 id="fork-session">Fork a Session for Experiments</h2>
     <h3>Try risky changes without touching the original session</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -621,6 +621,7 @@
             <div class="example-prompt" onclick="useExample(this)">Read all files in the workspace and give me a summary of what's there</div>
             <div class="example-prompt" onclick="useExample(this)">Initialize a git repo, create a README.md with a project description, and make an initial commit</div>
             <div class="example-prompt" onclick="useExample(this)">Create a simple TODO app with an HTML file and a Worker API backend. Put files in /src/</div>
+            <div class="example-prompt" onclick="useExample(this)">/generate a cyberpunk cat wearing sunglasses, neon city background</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Documentation follow-up for #42 and #44. Adds the `/generate` slash command, image-generation entry points, and `generate_image` MCP tool to README, docs, how-to guides, and landing page examples.

## What changed

**README.md**
- New "Image generation (`/generate`)" feature section above Attachments
- Updated Attachments section to list `/generate` as the 4th image source
- Bumped `/mcp` tool count 47 → 48

**public/docs.html**
- New "Image Generation" section with entry-point table, limits, requirements
- New "Slash commands" bullet in Chat & Streaming describing the autocomplete menu
- Added `POST /session/:id/generate` to the session endpoints table
- Added `generate_image` to the MCP Chat tools table; noted `/generate` prefix auto-routing in `send_message`/`send_prompt`
- Bumped `/mcp` tool count 46 → 48

**public/howto.html**
- New "Generate an Image" how-to with slash menu walkthrough + MCP example
- Added to the TOC

**public/index.html**
- Added a `/generate a cyberpunk cat...` example prompt to the landing page chips

## Test plan

- ✅ `npx tsc --noEmit` passes
- ✅ `npx vitest run` — all 401 tests pass (docs only, no code changes)
- [ ] Manual: browse the deployed docs and howto pages to check rendering

beep-boop-🤖