### PR TITLE
docs: Artifacts repos live on Cloudflare, not GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ One Worker, three Durable Object classes:
 | **UserControl** | One per user | Config, sessions, memory, tasks, encrypted secrets |
 | **CodingAgent** | One per session | Chat loop, workspace (files + git), sandbox, prompts |
 
-Plus R2 for large file and attachment storage, Browser Rendering for headless Chrome, a per-session Artifacts repo on GitHub for a durable record of workspace changes, and your choice of LLM gateway (OpenCode, AI Gateway, or Workers AI via AI Gateway).
+Plus R2 for large file and attachment storage, Browser Rendering for headless Chrome, a per-session [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/) repo (git-compatible, hosted at `artifacts.cloudflare.net`) for a durable record of workspace changes, and your choice of LLM gateway (OpenCode, AI Gateway, or Workers AI via AI Gateway).
 
 ---
 
@@ -265,7 +265,9 @@ Built-in support for dispatching work to worker sessions and shepherding it to a
 
 ### Artifacts
 
-Every Dodo session automatically gets its own GitHub repo fork -- an **Artifacts repo** -- and workspace changes flush to it at the end of each agent turn. Forked sessions fork the Artifacts repo too, so branch history is preserved. You get a reviewable git history of what the agent did, without waiting for the agent to remember to commit.
+Every Dodo session automatically gets its own [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/) repo -- a git-compatible repo hosted at `artifacts.cloudflare.net`, cloneable by any standard git client with a repo-scoped token. Workspace changes flush to it at the end of each agent turn. Forked sessions fork the Artifacts repo too, so branch history is preserved. You get a reviewable git history of what the agent did, without waiting for the agent to remember to commit.
+
+Note: this is **separate** from the auto-draft-PR feature on GitHub, which only applies to orchestrated dispatch runs (`dispatch_repo_prompt`) that target a user-configured GitHub repo. Artifacts repos are always per-session and always on Cloudflare.
 
 ---
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -216,7 +216,7 @@
     <g filter="url(#s)">
       <rect x="685" y="165" width="170" height="60" rx="8" fill="#1e293b" stroke="url(#artifact)" stroke-width="1.5"/>
       <text x="770" y="184" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Artifacts</text>
-      <text x="770" y="200" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="9">Per-session GitHub repo</text>
+      <text x="770" y="200" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="9">Per-session Cloudflare repo</text>
       <text x="770" y="215" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="9">(auto-fork on session fork)</text>
     </g>
   </a>

--- a/docs/how-it-works.svg
+++ b/docs/how-it-works.svg
@@ -117,9 +117,9 @@
       <circle cx="685" cy="108" r="18" fill="url(#g4)"/>
       <text x="685" y="114" text-anchor="middle" fill="#fff" font-family="system-ui, sans-serif" font-size="14" font-weight="700">4</text>
       <text x="685" y="144" text-anchor="middle" class="step-title" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Results</text>
-      <text x="685" y="168" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Code committed,</text>
-      <text x="685" y="182" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">branch pushed, Artifacts</text>
-      <text x="685" y="196" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">flushed to GitHub.</text>
+      <text x="685" y="168" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Code committed, branch</text>
+      <text x="685" y="182" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">pushed, Artifacts flushed</text>
+      <text x="685" y="196" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">to Cloudflare.</text>
 
       <rect x="617" y="216" width="136" height="90" rx="6" fill="#0f172a"/>
       <text x="685" y="236" text-anchor="middle" fill="#4ade80" font-family="system-ui, sans-serif" font-size="9">&#x2713; Bug fixed</text>

--- a/docs/use-cases.svg
+++ b/docs/use-cases.svg
@@ -148,8 +148,8 @@
       <text x="378" y="537" class="card-title" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Artifacts Repo</text>
       <rect x="332" y="554" width="266" height="60" rx="6" fill="#0f172a"/>
       <text x="342" y="572" fill="#f97316" font-family="monospace" font-size="9">Every session auto-gets its own</text>
-      <text x="342" y="586" fill="#f97316" font-family="monospace" font-size="9">GitHub repo. Workspace changes</text>
-      <text x="342" y="600" fill="#f97316" font-family="monospace" font-size="9">flush at end of each agent turn.</text>
+      <text x="342" y="586" fill="#f97316" font-family="monospace" font-size="9">Cloudflare git repo. Changes flush</text>
+      <text x="342" y="600" fill="#f97316" font-family="monospace" font-size="9">at the end of each agent turn.</text>
       <text x="332" y="634" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Reviewable git history of what the agent</text>
       <text x="332" y="650" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">did -- without waiting for it to commit.</text>
       <text x="332" y="676" class="cta" fill="#4ade80" font-family="system-ui, sans-serif" font-size="10" font-weight="500">Forked sessions fork the Artifacts too.</text>


### PR DESCRIPTION
## Summary

The README and architecture diagrams mis-described per-session Artifacts repos as GitHub repos or GitHub forks. They're actually [Cloudflare Artifacts](https://developers.cloudflare.com/artifacts/) — a git-compatible storage product hosted at `artifacts.cloudflare.net`, separate from GitHub.

## What changed

- **README.md** — both Artifacts mentions now correctly describe the repos as Cloudflare-hosted. Added a note clarifying that the auto-draft-PR feature (which *does* target GitHub) is a separate orchestration feature.
- **docs/architecture.svg** — "Per-session GitHub repo" → "Per-session Cloudflare repo"
- **docs/how-it-works.svg** — step 4 "flushed to GitHub" → "flushed to Cloudflare"
- **docs/use-cases.svg** — "GitHub repo" card text → "Cloudflare git repo"

## Why

The code in \`src/coding-agent.ts\` uses \`env.ARTIFACTS.create(name)\` — Cloudflare's beta Artifacts binding — to create a per-session repo. These repos live at \`artifacts.cloudflare.net\` and are cloneable via standard git with a repo-scoped token. No GitHub involvement at all.

The GitHub auto-draft-PR code path is entirely separate (\`src/github-pr.ts\`), only fires during orchestrated dispatch runs (\`dispatch_repo_prompt\`), and explicitly parses \`github.com\` URLs from a user-configured repo.

beep-boop-🤖