### PR TITLE
Workers Builds auto-deploy + fix dodo-verify SSE flake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,11 @@ Autonomous coding agent on Cloudflare Workers. Self-hostable, multi-tenant, sand
 
 ## Deploying
 
-**Deploys are manual.** Run `npm run deploy` locally after merging to `main`. Workers Builds CI is disabled because the `"experimental"` compat flag (required by `@cloudflare/think` and the Agents SDK `subAgent()` facet API) blocks non-local deploys by design — see [issue #46](https://github.com/jonnyparris/dodo/issues/46). When Think graduates out of experimental, this can be re-enabled.
+**Auto-deploy on push to `main`** via Workers Builds. Trigger runs `npm run build` then `npx wrangler deploy`.
+
+The `experimental` compat flag is fine here — only `wrangler versions upload` rejects it (code 10021), not `wrangler deploy`. Preview/non-production triggers are intentionally not configured for this reason. PR validation runs via `.github/workflows/dodo-verify.yml` (typecheck + test), no preview deploy.
+
+Manual deploy still works: `npm run deploy` from a workstation authenticated to your Cloudflare account.
 
 ## Git Discipline — Pick the Workflow That Matches Your Runtime
 

--- a/README.md
+++ b/README.md
@@ -366,11 +366,11 @@ npm run deploy       # Build + deploy
 
 ### Deploying
 
-Deploys are **manual**: run `npm run deploy` from a workstation authenticated to your Cloudflare account.
+**Push to `main` auto-deploys** via Workers Builds. The trigger runs `npm run build` then `npx wrangler deploy`.
 
-Workers Builds CI was intentionally disabled because Dodo uses the `"experimental"` compatibility flag (required by `@cloudflare/think` and the Agents SDK `subAgent()` facet API). The `experimental` flag is designed to block non-local deploys — local `wrangler deploy` currently works, but the Workers Builds service enforces the policy and rejects every automated deploy. See [issue #46](https://github.com/jonnyparris/dodo/issues/46) for the full diagnosis.
+The `experimental` compatibility flag (required by `@cloudflare/think` and the Agents SDK `subAgent()` facet API) is fine for `wrangler deploy` — only the stricter `wrangler versions upload` rejects it (code 10021). Preview deploys for non-`main` branches are intentionally not configured because they would use `versions upload` and fail. PR validation runs via [dodo-verify.yml](.github/workflows/dodo-verify.yml) (typecheck + test).
 
-When `@cloudflare/think` graduates out of experimental, the flag can be removed and Workers Builds re-enabled.
+Manual deploy still works: `npm run deploy` from a workstation authenticated to your Cloudflare account. See [issue #46](https://github.com/jonnyparris/dodo/issues/46) for the diagnosis history.
 
 ## Contributing
 

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -5217,10 +5217,20 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.clients.set(writer, Promise.resolve());
     this.setState({ ...this.readSessionDetails() });
 
-    void this.writeEvent(writer, { data: this.readSessionDetails(), type: "ready" });
+    // Catches required: if the client disconnects before the first writes
+    // resolve, the readable side tears down and writer.write() rejects with
+    // "The readable side of this TransformStream is no longer readable".
+    // Without a handler that surfaces as an unhandled rejection in tests.
+    void this.writeEvent(writer, { data: this.readSessionDetails(), type: "ready" })
+      .catch(() => {
+        this.clients.delete(writer);
+      });
     // Replay current todos so a freshly-connected client is hydrated without
     // needing a separate fetch round-trip.
-    void this.writeEvent(writer, { data: { items: this.listTodos() }, type: "todos" });
+    void this.writeEvent(writer, { data: { items: this.listTodos() }, type: "todos" })
+      .catch(() => {
+        this.clients.delete(writer);
+      });
 
     // Periodic heartbeat. Cloudflare and intermediate proxies drop idle
     // SSE connections after ~100s — without a heartbeat, long-idle
@@ -5241,7 +5251,9 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       () => {
         clearInterval(heartbeatHandle);
         this.clients.delete(writer);
-        try { void writer.close(); } catch { /* stream may already be closed */ }
+        // close() returns a promise that can reject async — must use .catch()
+        // not try/catch (which only catches sync throws).
+        void writer.close().catch(() => { /* stream may already be closed */ });
         this.setState({ ...this.readSessionDetails() });
       },
       { once: true },

--- a/src/user-control.ts
+++ b/src/user-control.ts
@@ -3165,14 +3165,22 @@ export class UserControl extends DurableObject<Env> {
     const writer = stream.writable.getWriter();
     this.sseClients.set(writer, Promise.resolve());
 
-    // Send initial ready event with session count
-    void this.writeUserEvent(writer, { type: "ready", sessionCount: this.listSessions().length });
+    // Send initial ready event with session count.
+    // The .catch() is required: if the client disconnects before the first
+    // write resolves, the readable side is torn down and writer.write() rejects
+    // with "The readable side of this TransformStream is no longer readable".
+    // Without a handler that surfaces as an unhandled rejection in tests.
+    void this.writeUserEvent(writer, { type: "ready", sessionCount: this.listSessions().length })
+      .catch(() => {
+        this.sseClients.delete(writer);
+      });
 
     request.signal.addEventListener(
       "abort",
       () => {
         this.sseClients.delete(writer);
-        try { void writer.close(); } catch { /* stream may already be closed */ }
+        // close() can also reject if the readable side is already gone — swallow.
+        void writer.close().catch(() => { /* stream may already be closed */ });
       },
       { once: true },
     );


### PR DESCRIPTION
## Summary

**Two changes:**

1. **Workers Builds re-enabled** for dodo with a single `Deploy default branch` trigger on `main` running `npm run build && npx wrangler deploy`. The non-production preview trigger that was failing on every PR push has been deleted via API (it ran `wrangler versions upload`, which is the only command that hits the `experimental` flag block, code 10021). README + AGENTS.md updated to reflect that auto-deploy is live; `wrangler deploy` doesn't reject experimental flags, only `versions upload` does.

2. **Fix SSE TransformStream unhandled rejection** that was flaking `dodo-verify.yml` on roughly half of CI runs. Two handlers (UserControl.openUserEventStream and CodingAgent.openEventStream) did fire-and-forget writes without `.catch()`. When a client disconnected mid-write, the rejection surfaced as an unhandled rejection and vitest failed the run despite all 642 tests passing. Also fixed `try/catch` around `void writer.close()` — that pattern only catches sync throws but close() returns a promise, so switched to `.catch()`.

The flake fix was carried on this PR because it was blocking the docs from merging. Closes the operational fallout from #46.

## Test plan

- After merge, push to `main` should trigger the `Deploy default branch` build and deploy successfully.
- PR pushes no longer trigger Workers Builds (no preview trigger), so they only get the `dodo-verify.yml` typecheck/test signal — which should now be reliably green.
- Ran tests 3x locally after the SSE fix — all clean (642/642, 0 unhandled rejections each time).

beep-boop-🤖