### PR TITLE
fix(executor): pass ownerId to AllowlistOutbound via workerd per-call props

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { Workspace } from "@cloudflare/shell";
 import type { AttachmentRef } from "./attachments";
 import { createWorkspaceGit, defaultAuthor, resolveRemoteToken, verifyRemoteBranch } from "./git";
-import { wrapOutboundWithOwner } from "./executor";
+import { bindOutboundWithOwner } from "./executor";
 import { createPullRequest } from "./github-pr";
 import { normalizePath } from "./paths";
 import { createBrowserTools } from "./browser/tools";
@@ -1710,12 +1710,13 @@ function buildTools(
   const gitTools = buildGitTools(env, workspace, config, options?.ownerEmail);
 
   if (env.LOADER) {
-    // Wrap OUTBOUND so codemode fetches from the AI-tool sandbox carry an
-    // `x-dodo-owner-id` header — without it AllowlistOutbound can't resolve
-    // the calling user's GitHub/GitLab tokens and falls back to no auth.
-    // The HTTP `/execute` path already wraps via `runSandboxedCode`; this
-    // closes the same gap for the agent-loop path. (audit follow-up F2)
-    const outbound = wrapOutboundWithOwner(env.OUTBOUND ?? null, options?.ownerId);
+    // Bind OUTBOUND with per-call props carrying the owner identity so
+    // AllowlistOutbound can resolve the caller's GitHub/GitLab tokens.
+    // Without it, codemode fetches from the AI-tool path fall back to no
+    // auth. The HTTP `/execute` path applies the same binding via
+    // `runSandboxedCode`; this closes the same gap for the agent-loop
+    // path. (audit follow-up F2)
+    const outbound = bindOutboundWithOwner(env.OUTBOUND, options?.ownerId);
 
     const codemodeTool = createExecuteTool({
       tools: workspaceTools,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -2,48 +2,39 @@ import { DynamicWorkerExecutor, resolveProvider } from "@cloudflare/codemode";
 import type { Workspace } from "@cloudflare/shell";
 import { stateTools } from "@cloudflare/shell/workers";
 import type { ExecuteResult } from "@cloudflare/codemode";
+import type { AllowlistOutbound } from "./outbound";
 import type { Env } from "./types";
 
 /**
- * Header name for injecting the session owner ID into outbound requests.
- * Read by AllowlistOutbound.injectAuth to look up per-user secrets in
- * UserControl. The header is stripped before the request leaves the
- * Worker (see src/outbound.ts).
- */
-export const OWNER_ID_HEADER = "x-dodo-owner-id";
-
-/**
- * Wrap the OUTBOUND service binding so every fetch() the sandbox makes
- * carries an `x-dodo-owner-id` header bound to the calling user.
+ * Bind the OUTBOUND self-binding with per-call props carrying the owner
+ * identity, so AllowlistOutbound can resolve per-user secrets without
+ * trusting any sandbox-controlled channel.
  *
- * Without this wrapper, AllowlistOutbound has no way to resolve which
- * user's encrypted secrets to use, so per-user GitHub/GitLab tokens
- * never reach outbound requests from codemode and the env-var fallback
- * is also skipped (audit finding H4).
+ * Why props, not a wrapper: workerd has two rules in tension that ruled
+ * out earlier attempts at this:
  *
- * Exported because the AI-tool codemode path in `agentic.ts` also needs
- * to apply the same wrapper — without it, owner-id was only injected
- * for the HTTP `/execute` route, not for sandbox fetches issued via the
- * agent loop's `codemode` tool.
+ *   1. `globalOutbound` must be a real `Fetcher` produced by the runtime
+ *      — not a duck-typed `{ fetch }` cast `as Fetcher`.
+ *   2. The Fetcher must be transferable across the `LOADER.get()` boundary
+ *      into the codemode-spawned sandbox — a stub from another `LOADER.get()`
+ *      is NOT transferable.
+ *
+ * `LoopbackServiceStub({ props })` returns a real, transferable Fetcher that
+ * carries `props` through workerd's RPC mechanism. The receiving entrypoint
+ * (AllowlistOutbound) reads them from `this.ctx.props`. Sandboxed code never
+ * sees the owner identity and cannot forge it.
+ *
+ * Returns the original outbound unchanged when there's no ownerId or no
+ * outbound — both safe (AllowlistOutbound treats missing props as "no
+ * per-user auth available", same as before).
  */
-export function wrapOutboundWithOwner(outbound: Fetcher | null, ownerId: string | undefined): Fetcher | null {
-  if (!outbound || !ownerId) return outbound;
-
-  // Return a Fetcher-shaped object. Workers runtime requires the real
-  // ServiceStub at the binding level, but accepts any object exposing
-  // `fetch(...)` once codemode has captured the reference.
-  const wrapped = {
-    fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
-      const request = new Request(input, init);
-      const headers = new Headers(request.headers);
-      // Don't allow the sandboxed code to spoof the owner header — always
-      // overwrite with the server-resolved value.
-      headers.set(OWNER_ID_HEADER, ownerId);
-      return outbound.fetch(new Request(request, { headers }));
-    },
-  } as unknown as Fetcher;
-
-  return wrapped;
+export function bindOutboundWithOwner(
+  outbound: LoopbackServiceStub<AllowlistOutbound> | undefined,
+  ownerId: string | undefined,
+): Fetcher | null {
+  if (!outbound) return null;
+  if (!ownerId) return outbound;
+  return outbound({ props: { ownerId } });
 }
 
 export async function runSandboxedCode(input: {
@@ -52,8 +43,8 @@ export async function runSandboxedCode(input: {
   workspace: Workspace;
   /**
    * Stable identifier for the calling user (typically the hex string of
-   * their UserControl DO ID). Forwarded to AllowlistOutbound so per-user
-   * secrets resolve correctly inside the sandbox.
+   * their UserControl DO ID). Forwarded to AllowlistOutbound via per-call
+   * props so per-user secrets resolve correctly inside the sandbox.
    */
   ownerId?: string;
 }): Promise<ExecuteResult> {
@@ -61,11 +52,7 @@ export async function runSandboxedCode(input: {
     throw new Error("Dynamic Worker loader is not configured");
   }
 
-  // Pass the real OUTBOUND ServiceStub directly. The Workers runtime enforces
-  // that globalOutbound must be a Fetcher produced by a service binding —
-  // plain objects cast via `as Fetcher` fail with a type error at runtime.
-  const baseOutbound = input.env.OUTBOUND ?? null;
-  const outbound = wrapOutboundWithOwner(baseOutbound, input.ownerId);
+  const outbound = bindOutboundWithOwner(input.env.OUTBOUND, input.ownerId);
 
   const executor = new DynamicWorkerExecutor({
     globalOutbound: outbound,

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -1,6 +1,5 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { getSharedIndexStub, resolveAdminEmail } from "./auth";
-import { OWNER_ID_HEADER } from "./executor";
 import { MCP_CATALOG } from "./mcp-catalog";
 import type { Env } from "./types";
 
@@ -46,19 +45,33 @@ function secretKeyForHost(hostname: string): string | undefined {
 }
 
 /**
+ * Per-call props passed by the executor when binding `OUTBOUND` for a
+ * sandbox run. Read off `this.ctx.props` inside `fetch()`.
+ *
+ * Sandboxed code cannot tamper with these — workerd injects them via
+ * the runtime mechanism behind `LoopbackServiceStub({ props })`, not
+ * via the request itself.
+ */
+export interface AllowlistOutboundProps {
+  ownerId?: string;
+}
+
+/**
  * WorkerEntrypoint that intercepts all outbound fetch() calls from sandboxed
  * dynamic workers. Checks the hostname against the SharedIndex allowlist and
  * blocks requests to hosts that are not explicitly allowed.
  *
  * For allowlisted hosts that match a known provider (GitHub, GitLab), resolves
  * per-user authentication tokens from the owner's UserControl DO via the
- * `x-dodo-owner-id` header. Falls back to env var tokens only for the admin
- * account.
+ * `ownerId` prop on `this.ctx.props`. Falls back to env var tokens only for
+ * the admin account.
  *
  * Configured as a self-referencing service binding (OUTBOUND) in wrangler.jsonc
- * and passed as `globalOutbound` to DynamicWorkerExecutor.
+ * and passed as `globalOutbound` to DynamicWorkerExecutor — wrapped per call
+ * via `env.OUTBOUND({ props: { ownerId } })` so workerd's runtime propagates
+ * the owner identity tamper-proof.
  */
-export class AllowlistOutbound extends WorkerEntrypoint<Env> {
+export class AllowlistOutbound extends WorkerEntrypoint<Env, AllowlistOutboundProps> {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     const hostname = url.hostname.toLowerCase();
@@ -81,13 +94,12 @@ export class AllowlistOutbound extends WorkerEntrypoint<Env> {
       }
     }
 
-    // Extract and strip owner identity header before forwarding
-    const ownerId = request.headers.get(OWNER_ID_HEADER);
-    const headers = new Headers(request.headers);
-    headers.delete(OWNER_ID_HEADER);
+    // Pull owner identity from per-call props — sandboxed code can't tamper
+    // with workerd's props mechanism the way it could with a request header.
+    const ownerId = this.ctx.props?.ownerId;
 
-    // Inject authentication headers for known providers
-    await this.injectAuth(hostname, headers, ownerId);
+    const headers = new Headers(request.headers);
+    await this.injectAuth(hostname, headers, ownerId ?? null);
 
     // Clone via the original request to preserve all properties (cf, signal, etc.)
     const outboundRequest = new Request(request, { headers });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { Artifacts } from "./artifacts-types";
 import type { CodingAgent } from "./coding-agent";
+import type { AllowlistOutbound } from "./outbound";
 import type { SharedIndex } from "./shared-index";
 import type { UserControl } from "./user-control";
 
@@ -28,7 +29,14 @@ export interface Env {
   GIT_AUTHOR_NAME?: string;
   LOADER?: WorkerLoader;
   OPENCODE_BASE_URL: string;
-  OUTBOUND?: Fetcher;
+  /**
+   * Self-binding to {@link AllowlistOutbound}. Typed as a
+   * `LoopbackServiceStub` so callers can invoke
+   * `env.OUTBOUND({ props: { ownerId } })` to receive a per-call Fetcher
+   * with the owner identity carried via workerd's runtime props
+   * mechanism — see src/outbound.ts for the consumer side.
+   */
+  OUTBOUND?: LoopbackServiceStub<AllowlistOutbound>;
   WORKER_URL: string;
   WORKSPACE_BUCKET?: R2Bucket;
   /**

--- a/test/outbound.test.ts
+++ b/test/outbound.test.ts
@@ -198,3 +198,73 @@ describe("AllowlistOutbound auth injection", () => {
     });
   });
 });
+
+// ── bindOutboundWithOwner ────────────────────────────────────────────────
+
+import { bindOutboundWithOwner } from "../src/executor";
+import type { AllowlistOutbound } from "../src/outbound";
+
+describe("bindOutboundWithOwner", () => {
+  it("returns null when outbound is undefined", () => {
+    expect(bindOutboundWithOwner(undefined, "owner-1")).toBeNull();
+  });
+
+  it("returns the outbound stub unchanged when ownerId is undefined", () => {
+    // No props to bind → return the bare stub. AllowlistOutbound treats
+    // missing props.ownerId as "no per-user auth available" — same as
+    // before this fix.
+    const outboundCalls: unknown[] = [];
+    const fakeOutbound = Object.assign(
+      ((opts: unknown) => {
+        outboundCalls.push(opts);
+        return {} as Fetcher;
+      }) as unknown as LoopbackServiceStub<AllowlistOutbound>,
+      { fetch: vi.fn() },
+    );
+
+    const result = bindOutboundWithOwner(fakeOutbound, undefined);
+
+    expect(result).toBe(fakeOutbound);
+    expect(outboundCalls).toEqual([]);
+  });
+
+  it("invokes the loopback stub with props.ownerId when both are provided", () => {
+    const propsBoundFetcher = { __id: "props-bound" } as unknown as Fetcher;
+    const outboundCalls: Array<{ props?: { ownerId?: string } }> = [];
+    const fakeOutbound = Object.assign(
+      ((opts: { props?: { ownerId?: string } }) => {
+        outboundCalls.push(opts);
+        return propsBoundFetcher;
+      }) as unknown as LoopbackServiceStub<AllowlistOutbound>,
+      { fetch: vi.fn() },
+    );
+
+    const result = bindOutboundWithOwner(fakeOutbound, "owner-abc");
+
+    expect(outboundCalls).toEqual([{ props: { ownerId: "owner-abc" } }]);
+    expect(result).toBe(propsBoundFetcher);
+  });
+
+  it("does not mix props across ownerIds", () => {
+    const outboundCalls: Array<{ props?: { ownerId?: string } }> = [];
+    const fakeOutbound = Object.assign(
+      ((opts: { props?: { ownerId?: string } }) => {
+        outboundCalls.push(opts);
+        return {} as Fetcher;
+      }) as unknown as LoopbackServiceStub<AllowlistOutbound>,
+      { fetch: vi.fn() },
+    );
+
+    bindOutboundWithOwner(fakeOutbound, "owner-1");
+    bindOutboundWithOwner(fakeOutbound, "owner-2");
+    bindOutboundWithOwner(fakeOutbound, "owner-1");
+
+    expect(outboundCalls).toEqual([
+      { props: { ownerId: "owner-1" } },
+      { props: { ownerId: "owner-2" } },
+      { props: { ownerId: "owner-1" } },
+    ]);
+  });
+});
+
+


### PR DESCRIPTION
## Summary

Third (and hopefully final) attempt at fixing codemode outbound `fetch()`. Uses workerd's native **per-call props on `LoopbackServiceStub`** — a primitive purpose-built for exactly this case. No wrapper Worker, no header injection, sandbox cannot forge ownerId.

## Why the previous attempts failed

1. **Original duck-typed wrapper** (`{ fetch } as Fetcher`): rejected at executor instantiation. Workerd validates `globalOutbound` must be a real `ServiceStub`.
2. **PR #52** (`LOADER.get()` wrapper Worker): returned a real `Fetcher`, but the stub couldn't transfer across the `LOADER.get()` boundary into the codemode sandbox. Reverted in #53.

## What this PR does

`OUTBOUND` is already a self-binding to `AllowlistOutbound` (declared in `wrangler.jsonc`). Loopback stubs in workerd are callable:

```ts
const outbound = env.OUTBOUND({ props: { ownerId } });
// → real, transferable Fetcher with per-call props
```

The receiving `WorkerEntrypoint` reads them from `this.ctx.props`. Sandboxed code never sees the ownerId — props ride workerd's RPC channel, not the request.

## Changes

- `src/types.ts`: type `OUTBOUND` as `LoopbackServiceStub<AllowlistOutbound>`
- `src/outbound.ts`: `AllowlistOutbound extends WorkerEntrypoint<Env, AllowlistOutboundProps>`, reads `this.ctx.props?.ownerId`. `OWNER_ID_HEADER` constant deleted
- `src/executor.ts`: `wrapOutboundWithOwner` → `bindOutboundWithOwner` — one liner that calls `outbound({ props: { ownerId } })`
- `src/agentic.ts`: same call-site updated
- `test/outbound.test.ts`: 4 new unit tests (643 → 647 passing)

## Verification plan

Unlike PR #52 which I shipped without a runtime test (mistake — see [memory/learnings.md][1]), this PR will be live-tested **before** marking ready:

1. Merge to a topic branch, deploy to production
2. Fresh codemode session: `await fetch("https://example.com")` → expect 200, not the transfer error
3. Confirm in `AllowlistOutbound` logs that ownerId is being read from props
4. Then mark ready / merge to main

[1]: this is happening on personal infra, not flagging the file location for the public PR

🤖 generated by ruskin's agent