### PR TITLE
refactor(mcp-client): rename mcp-gatekeeper to mcp-client

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -8,7 +8,7 @@ import { createWorkspaceGit, defaultAuthor, resolveRemoteToken, verifyRemoteBran
 import { createPullRequest } from "./github-pr";
 import { normalizePath } from "./paths";
 import { createBrowserTools } from "./browser/tools";
-import type { McpGatekeeper } from "./mcp-gatekeeper";
+import type { McpClient } from "./mcp-client";
 import { getKnownRepo, listKnownRepos, parseRemoteSpec } from "./repos";
 import { createWorkspaceTools, createExecuteTool } from "./think-adapter";
 import { runTypecheck } from "./typecheck";
@@ -31,7 +31,7 @@ interface BuildToolsOptions {
   ownerId?: string;
   ownerEmail?: string;
   stateBackend?: StateBackend;
-  mcpGatekeepers?: McpGatekeeper[];
+    mcpGatekeepers?: McpClient[];
   /**
    * OAuth MCP tools pre-fetched from the per-user hub DO. Session DOs don't
    * hold OAuth credentials locally — they pass the cached tool list here
@@ -1970,7 +1970,7 @@ export function buildToolsForThink(
   config: AppConfig,
   options?: BuildToolsOptions & {
     agent?: { mcp?: unknown };
-    mcpGatekeepers?: McpGatekeeper[];
+  mcpGatekeepers?: McpClient[];
   },
 ): Record<string, AnyTool> {
   const tools = buildTools(env, workspace, config, options);
@@ -2000,7 +2000,7 @@ export function buildToolsForThink(
  * by the gatekeeper's listTools(). We use jsonSchema() passthrough for the
  * input schema since MCP tools define JSON Schema directly, not Zod.
  */
-function buildMcpTools(gatekeepers: McpGatekeeper[], existingNames: Set<string>): Record<string, AnyTool> {
+function buildMcpTools(gatekeepers: McpClient[], existingNames: Set<string>): Record<string, AnyTool> {
   const tools: Record<string, AnyTool> = {};
 
   for (const gk of gatekeepers) {

--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -14,7 +14,7 @@ import { runSandboxedCode } from "./executor";
 import { ExploreAgent, type ExploreQueryOpts, type ExploreQueryResult } from "./explore-agent";
 import { createWorkspaceGit, defaultAuthor, resolveRemoteToken, verifyRemoteBranch } from "./git";
 import { log } from "./logger";
-import { HttpMcpGatekeeper, type McpGatekeeper, type McpGatekeeperConfig } from "./mcp-gatekeeper";
+import { HttpMcpClient, type McpClient, type McpClientConfig } from "./mcp-client";
 import { sendNotification } from "./notify";
 import { normalizePath } from "./paths";
 import { PresenceTracker } from "./presence";
@@ -432,7 +432,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
   /** Set by assembleContext() when messages are dropped due to token budget. */
   private _contextTruncated = false;
   /** Connected MCP gatekeepers, populated by connectMcpServers(). */
-  private mcpGatekeepers: McpGatekeeper[] = [];
+  private mcpGatekeepers: McpClient[] = [];
   /**
    * OAuth MCP tools federated from the per-user hub DO.
    *
@@ -5817,7 +5817,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       if (!configsRes.ok) return;
 
       const { configs } = (await configsRes.json()) as {
-        configs: Array<McpGatekeeperConfig & { overridden: boolean }>;
+        configs: Array<McpClientConfig & { overridden: boolean }>;
       };
 
       // Gate browser-rendering MCP on the per-session browser_enabled flag.
@@ -5835,7 +5835,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       if (enabled.length === 0) return;
 
       // Resolve encrypted headers and connect each gatekeeper
-      const connected: McpGatekeeper[] = [];
+      const connected: McpClient[] = [];
       for (const config of enabled) {
         try {
           // Resolve headers via internal secret endpoint
@@ -5854,7 +5854,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
             }
           }
 
-          const gk = new HttpMcpGatekeeper({
+          const gk = new HttpMcpClient({
             ...config,
             headers,
           }, this.mcpDepth);

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -3,7 +3,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 
 // ─── Types ───
 
-export interface McpGatekeeperConfig {
+export interface McpClientConfig {
   id: string;
   name: string;
   type: "http" | "service-binding";
@@ -26,7 +26,7 @@ export interface McpToolInfo {
   inputSchema?: unknown;
 }
 
-export interface McpGatekeeper {
+export interface McpClient {
   connect(): Promise<void>;
   disconnect(): void;
   listTools(): Promise<McpToolInfo[]>;
@@ -37,25 +37,25 @@ export interface McpGatekeeper {
   isConnected(): boolean;
 }
 
-// ─── HTTP MCP Gatekeeper ───
+// ─── HTTP MCP Client ───
 
 /**
- * HTTP MCP Gatekeeper — wraps a remote MCP server via Streamable HTTP transport.
+ * HTTP MCP Client — wraps a remote MCP server via Streamable HTTP transport.
  * Uses @modelcontextprotocol/sdk Client to connect and communicate.
  */
-export class HttpMcpGatekeeper implements McpGatekeeper {
+export class HttpMcpClient implements McpClient {
   private client: Client | null = null;
   private transport: StreamableHTTPClientTransport | null = null;
   private connected = false;
   private cachedTools: McpToolInfo[] | null = null;
   private mcpDepth = 0;
 
-  constructor(private config: McpGatekeeperConfig, mcpDepth = 0) {
+  constructor(private config: McpClientConfig, mcpDepth = 0) {
     if (config.type !== "http") {
-      throw new Error(`HttpMcpGatekeeper only supports type "http", got "${config.type}"`);
+      throw new Error(`HttpMcpClient only supports type "http", got "${config.type}"`);
     }
     if (!config.url) {
-      throw new Error("HttpMcpGatekeeper requires a url");
+      throw new Error("HttpMcpClient requires a url");
     }
     this.mcpDepth = mcpDepth;
   }
@@ -79,7 +79,7 @@ export class HttpMcpGatekeeper implements McpGatekeeper {
 
     this.transport = new StreamableHTTPClientTransport(url, { requestInit });
     this.client = new Client(
-      { name: `dodo-gatekeeper-${this.config.id}`, version: "1.0.0" },
+      { name: `dodo-client-${this.config.id}`, version: "1.0.0" },
       { capabilities: {} },
     );
 

--- a/src/user-control.ts
+++ b/src/user-control.ts
@@ -18,7 +18,7 @@ import {
   PBKDF2_DEFAULT_ITERATIONS,
   PBKDF2_LEGACY_ITERATIONS,
 } from "./crypto";
-import { HttpMcpGatekeeper, type McpGatekeeperConfig } from "./mcp-gatekeeper";
+import { HttpMcpClient, type McpClientConfig } from "./mcp-client";
 import { log } from "./logger";
 import { advanceStep, getInitialState, type OnboardingState } from "./onboarding";
 import { sendRunNotification } from "./notify";
@@ -740,7 +740,7 @@ export class UserControl extends DurableObject<Env> {
         if (!row) return Response.json({ error: `MCP config ${id} not found` }, { status: 404 });
         const ownerEmail = request.headers.get("x-owner-email") ?? "";
         const config = await this.resolveMcpConfigHeaders(this.mapMcpConfigRow(row), ownerEmail);
-        const gatekeeper = new HttpMcpGatekeeper(config);
+        const gatekeeper = new HttpMcpClient(config);
         const result = await gatekeeper.testConnection();
         return Response.json(result);
       }
@@ -1937,7 +1937,7 @@ export class UserControl extends DurableObject<Env> {
    * Create an MCP config, storing headers as encrypted secrets.
    * The mcp_configs table stores only header key names (not values).
    */
-  private async createMcpConfigEncrypted(input: { name: string; type: string; auth_type: "oauth" | "static_headers"; url?: string; headers?: Record<string, string>; enabled: boolean }, ownerEmail: string): Promise<McpGatekeeperConfig & { headerKeys?: string[] }> {
+  private async createMcpConfigEncrypted(input: { name: string; type: string; auth_type: "oauth" | "static_headers"; url?: string; headers?: Record<string, string>; enabled: boolean }, ownerEmail: string): Promise<McpClientConfig & { headerKeys?: string[] }> {
     const id = crypto.randomUUID();
     const now = nowEpoch();
     const headerKeys = input.headers ? Object.keys(input.headers) : [];
@@ -1961,7 +1961,7 @@ export class UserControl extends DurableObject<Env> {
   /**
    * Update an MCP config, replacing encrypted header secrets if new headers provided.
    */
-  private async updateMcpConfigEncrypted(id: string, patch: { name?: string; type?: string; auth_type?: "oauth" | "static_headers"; url?: string; headers?: Record<string, string>; enabled?: boolean }, ownerEmail: string): Promise<McpGatekeeperConfig & { headerKeys?: string[] }> {
+  private async updateMcpConfigEncrypted(id: string, patch: { name?: string; type?: string; auth_type?: "oauth" | "static_headers"; url?: string; headers?: Record<string, string>; enabled?: boolean }, ownerEmail: string): Promise<McpClientConfig & { headerKeys?: string[] }> {
     const current = this.getMcpConfigSafe(id);
     const now = nowEpoch();
 
@@ -2005,7 +2005,7 @@ export class UserControl extends DurableObject<Env> {
   }
 
   /** Resolve encrypted headers for actual MCP connection. */
-  private async resolveMcpConfigHeaders(config: McpGatekeeperConfig, ownerEmail: string): Promise<McpGatekeeperConfig> {
+  private async resolveMcpConfigHeaders(config: McpClientConfig, ownerEmail: string): Promise<McpClientConfig> {
     if (!config.headerKeys || config.headerKeys.length === 0) return config;
     if (!ownerEmail || !this.hasKeyEnvelope()) return config;
 
@@ -2020,7 +2020,7 @@ export class UserControl extends DurableObject<Env> {
     return { ...config, headers: Object.keys(headers).length > 0 ? headers : undefined };
   }
 
-  private getMcpConfigSafe(id: string): McpGatekeeperConfig & { headerKeys?: string[] } {
+  private getMcpConfigSafe(id: string): McpClientConfig & { headerKeys?: string[] } {
     const row = (Array.from(this.ctx.storage.sql.exec("SELECT id, name, type, auth_type, url, headers_json, enabled FROM mcp_configs WHERE id = ?", id))[0] as SqlRow | null);
     if (!row) throw new Error(`MCP config ${id} not found`);
     return this.mapMcpConfigRowSafe(row);
@@ -2029,7 +2029,7 @@ export class UserControl extends DurableObject<Env> {
   /**
    * List MCP configs for display. Returns header key names but not values.
    */
-  private listMcpConfigsSafe(): Array<McpGatekeeperConfig & { headerKeys?: string[] }> {
+  private listMcpConfigsSafe(): Array<McpClientConfig & { headerKeys?: string[] }> {
     return Array.from(this.ctx.storage.sql.exec("SELECT id, name, type, auth_type, url, headers_json, enabled FROM mcp_configs ORDER BY name ASC")).map((row) => this.mapMcpConfigRowSafe(row));
   }
 
@@ -2232,7 +2232,7 @@ export class UserControl extends DurableObject<Env> {
   /**
    * Map a row to safe config (headers_json now stores key names array, not values).
    */
-  private mapMcpConfigRowSafe(row: SqlRow): McpGatekeeperConfig & { headerKeys?: string[] } {
+  private mapMcpConfigRowSafe(row: SqlRow): McpClientConfig & { headerKeys?: string[] } {
     const headersJsonStr = row.headers_json ? String(row.headers_json) : null;
     let headerKeys: string[] | undefined;
 
@@ -2262,7 +2262,7 @@ export class UserControl extends DurableObject<Env> {
   }
 
   /** Legacy mapper used only for internal test endpoint resolution. */
-  private mapMcpConfigRow(row: SqlRow): McpGatekeeperConfig & { headerKeys?: string[] } {
+  private mapMcpConfigRow(row: SqlRow): McpClientConfig & { headerKeys?: string[] } {
     const headersJsonStr = row.headers_json ? String(row.headers_json) : null;
     let headerKeys: string[] | undefined;
 
@@ -2313,7 +2313,7 @@ export class UserControl extends DurableObject<Env> {
     );
   }
 
-  private getEffectiveMcpConfigs(sessionId: string): Array<McpGatekeeperConfig & { overridden: boolean }> {
+  private getEffectiveMcpConfigs(sessionId: string): Array<McpClientConfig & { overridden: boolean }> {
     const configs = this.listMcpConfigsSafe();
     const overrides = this.listMcpOverrides(sessionId);
     const overrideMap = new Map(overrides.map((o) => [o.mcpConfigId, o.enabled]));

--- a/test/mcp-config.test.ts
+++ b/test/mcp-config.test.ts
@@ -203,10 +203,10 @@ describe("MCP Catalog", () => {
   });
 });
 
-describe("McpGatekeeper interface", () => {
-  it("HttpMcpGatekeeper: construct with valid config", async () => {
+describe("McpClient interface", () => {
+  it("HttpMcpClient: construct with valid config", async () => {
     // Dynamic import to avoid issues with MCP SDK in test runtime
-    const { HttpMcpGatekeeper } = await import("../src/mcp-gatekeeper");
+    const { HttpMcpClient } = await import("../src/mcp-client");
 
     const config = {
       id: "test-server",
@@ -218,15 +218,15 @@ describe("McpGatekeeper interface", () => {
       enabled: true,
     };
 
-    const gatekeeper = new HttpMcpGatekeeper(config);
+    const gatekeeper = new HttpMcpClient(config);
     expect(gatekeeper).toBeTruthy();
     expect(gatekeeper.isConnected()).toBe(false);
   });
 
-  it("HttpMcpGatekeeper: rejects service-binding type", async () => {
-    const { HttpMcpGatekeeper } = await import("../src/mcp-gatekeeper");
+  it("HttpMcpClient: rejects service-binding type", async () => {
+    const { HttpMcpClient } = await import("../src/mcp-client");
 
-    expect(() => new HttpMcpGatekeeper({
+    expect(() => new HttpMcpClient({
       id: "wrong-type",
       name: "Wrong Type",
       type: "service-binding",
@@ -235,10 +235,10 @@ describe("McpGatekeeper interface", () => {
     })).toThrow(/only supports type "http"/);
   });
 
-  it("HttpMcpGatekeeper: rejects missing url", async () => {
-    const { HttpMcpGatekeeper } = await import("../src/mcp-gatekeeper");
+  it("HttpMcpClient: rejects missing url", async () => {
+    const { HttpMcpClient } = await import("../src/mcp-client");
 
-    expect(() => new HttpMcpGatekeeper({
+    expect(() => new HttpMcpClient({
       id: "no-url",
       name: "No URL",
       type: "http",

--- a/test/mcp-gatekeeper-unit.test.ts
+++ b/test/mcp-gatekeeper-unit.test.ts
@@ -1,13 +1,13 @@
 /**
- * Pure unit tests for HttpMcpGatekeeper constructor validation.
+ * Pure unit tests for HttpMcpClient constructor validation.
  * Extracted from mcp-config.test.ts to avoid importing the main worker module.
  * See: https://github.com/cloudflare/workers-sdk/issues/13191
  */
 import { describe, expect, it } from "vitest";
 
-describe("HttpMcpGatekeeper interface", () => {
+describe("HttpMcpClient interface", () => {
   it("construct with valid config", async () => {
-    const { HttpMcpGatekeeper } = await import("../src/mcp-gatekeeper");
+    const { HttpMcpClient } = await import("../src/mcp-client");
 
     const config = {
       id: "test-server",
@@ -19,15 +19,15 @@ describe("HttpMcpGatekeeper interface", () => {
       enabled: true,
     };
 
-    const gatekeeper = new HttpMcpGatekeeper(config);
+    const gatekeeper = new HttpMcpClient(config);
     expect(gatekeeper).toBeTruthy();
     expect(gatekeeper.isConnected()).toBe(false);
   });
 
   it("rejects service-binding type", async () => {
-    const { HttpMcpGatekeeper } = await import("../src/mcp-gatekeeper");
+    const { HttpMcpClient } = await import("../src/mcp-client");
 
-    expect(() => new HttpMcpGatekeeper({
+    expect(() => new HttpMcpClient({
       id: "wrong-type",
       name: "Wrong Type",
       type: "service-binding",
@@ -37,9 +37,9 @@ describe("HttpMcpGatekeeper interface", () => {
   });
 
   it("rejects missing url", async () => {
-    const { HttpMcpGatekeeper } = await import("../src/mcp-gatekeeper");
+    const { HttpMcpClient } = await import("../src/mcp-client");
 
-    expect(() => new HttpMcpGatekeeper({
+    expect(() => new HttpMcpClient({
       id: "no-url",
       name: "No URL",
       type: "http",


### PR DESCRIPTION
## Summary
- Rename \`src/mcp-gatekeeper.ts\` → \`src/mcp-client.ts\`
- Rename exported \`HttpMcpGatekeeper\` → \`HttpMcpClient\` (and related local types)
- Update callers in \`src/coding-agent.ts\` and \`src/user-control.ts\`

## Why
The file held a wrapper around \`@modelcontextprotocol/sdk\`'s HTTP transport for *consuming* third-party MCP servers — the inbound MCP client. The \`mcp-gatekeeper\` name suggested it belonged with \`mcp.ts\` and \`mcp-codemode.ts\` (the outbound MCP servers Dodo exposes). Renaming separates concerns visually. Per the \`improve-codebase-architecture\` audit.

## Test plan
- \`npm run typecheck\` — clean
- \`npm test\` — clean
- \`npm run lint\` — clean