### PR TITLE
refactor(mcp): extract shared helpers between mcp.ts and mcp-codemode.ts

### DIFF
--- a/src/mcp-codemode.ts
+++ b/src/mcp-codemode.ts
@@ -1,7 +1,8 @@
 import { getAgentByName } from "agents";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { canonicalizeEmail, getUserControlStub, resolveAdminEmail } from "./auth";
+import { getUserControlStub } from "./auth";
+import { errorResult, mcpUserEmail, propagateMcpDepth } from "./mcp-shared";
 import type { Env } from "./types";
 
 // ─── API Catalog ───
@@ -110,27 +111,6 @@ declare const catalog: CatalogEntry[];
 `;
 
 // ─── Helpers ───
-
-/**
- * Resolve the email to attribute MCP operations to.
- *
- * Prefers the explicit caller email (resolved upstream from the user-scoped
- * `dodo_*` token). Only falls back to ADMIN_EMAIL when no user email was
- * threaded — which now only happens for service-mode callers using the
- * shared `DODO_MCP_TOKEN` (audit finding H2).
- */
-function mcpUserEmail(env: Env, userEmail?: string): string {
-  const canonical = canonicalizeEmail(userEmail ?? null);
-  if (canonical) return canonical;
-  const admin = resolveAdminEmail(env);
-  if (!admin) throw new Error("ADMIN_EMAIL must be configured for MCP access. Set it as a secret or in wrangler.jsonc vars.");
-  console.warn("[mcp-codemode] Operation attributed to admin via service-mode fallback (no userEmail threaded).");
-  return admin;
-}
-
-function errorResult(data: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }], isError: true };
-}
 
 /** Truncate large responses to avoid blowing up the context window. */
 function truncateResponse(data: unknown, maxChars = 16_000): string {
@@ -257,7 +237,7 @@ async () => {
 // Routes requests to the appropriate internal Durable Object (UserControl or CodingAgent).
 
 function buildDodoClient(env: Env, userEmail: string | undefined, depth: number) {
-  const email = mcpUserEmail(env, userEmail);
+  const email = mcpUserEmail(env, userEmail, "mcp-codemode");
 
   return {
     async request(options: { method: string; path: string; query?: Record<string, string | number | boolean | undefined>; body?: unknown }) {
@@ -311,7 +291,7 @@ function buildDodoClient(env: Env, userEmail: string | undefined, depth: number)
         const agent = await getAgentByName(env.CODING_AGENT as never, sessionId);
         const agentHeaders = new Headers(headers);
         agentHeaders.set("x-dodo-session-id", sessionId);
-        agentHeaders.set("x-dodo-mcp-depth", String(depth + 1));
+        propagateMcpDepth(agentHeaders, depth);
         res = await agent.fetch(new Request(`https://coding-agent${targetPath}${url.search}`, { ...init, headers: agentHeaders }));
       } else {
         // Route to UserControl DO

--- a/src/mcp-shared.ts
+++ b/src/mcp-shared.ts
@@ -1,0 +1,29 @@
+import { canonicalizeEmail, resolveAdminEmail } from "./auth";
+import type { Env } from "./types";
+
+/**
+ * Resolve the MCP caller's email. Prefers an explicit userEmail (from a
+ * user-scoped dodo_* token validated upstream), falls back to ADMIN_EMAIL
+ * for service-mode callers using the shared DODO_MCP_TOKEN.
+ *
+ * When the fallback is taken we log a warning so operators can audit
+ * operations that get attributed to the admin. In production, review the
+ * log stream periodically to confirm the expected service-mode callers
+ * (CI etc.) are the only ones hitting this path.
+ */
+export function mcpUserEmail(env: Env, userEmail?: string, label = "mcp"): string {
+  const canonical = canonicalizeEmail(userEmail ?? null);
+  if (canonical) return canonical;
+  const email = resolveAdminEmail(env);
+  if (!email) throw new Error("ADMIN_EMAIL must be configured for MCP access. Set it as a secret or in wrangler.jsonc vars.");
+  console.warn(`[${label}] Operation attributed to admin via service-mode fallback (no userEmail threaded).`);
+  return email;
+}
+
+export function errorResult(data: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }], isError: true };
+}
+
+export function propagateMcpDepth(headers: Headers, depth: number): void {
+  headers.set("x-dodo-mcp-depth", String(depth + 1));
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,34 +1,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getAgentByName } from "agents";
 import { z } from "zod";
-import { canonicalizeEmail, getSharedIndexStub, getUserControlStub, isAdmin, resolveAdminEmail } from "./auth";
+import { getSharedIndexStub, getUserControlStub, isAdmin } from "./auth";
 import { log } from "./logger";
 import { messageLimiter, promptLimiter } from "./rate-limit";
 import { createDraftPrForRun, createGithubRepo } from "./github-pr";
 import { pollVerifyWorkflow, triggerVerifyWorkflow } from "./github-actions";
 import { getKnownRepo, listKnownRepos } from "./repos";
 import { forkSessionInternal, SourceSessionMissingError } from "./sessions";
+import { errorResult, mcpUserEmail, propagateMcpDepth } from "./mcp-shared";
 import type { CodingAgent } from "./coding-agent";
 import type { Env, WorkerRunRecord } from "./types";
-
-/**
- * Resolve the MCP caller's email. Prefers an explicit userEmail (from a
- * user-scoped dodo_* token validated upstream), falls back to ADMIN_EMAIL
- * for service-mode callers using the shared DODO_MCP_TOKEN.
- *
- * When the fallback is taken we log a warning so operators can audit
- * operations that get attributed to the admin. In production, review the
- * log stream periodically to confirm the expected service-mode callers
- * (CI etc.) are the only ones hitting this path.
- */
-function mcpUserEmail(env: Env, userEmail?: string): string {
-  const canonical = canonicalizeEmail(userEmail ?? null);
-  if (canonical) return canonical;
-  const email = resolveAdminEmail(env);
-  if (!email) throw new Error("ADMIN_EMAIL must be configured for MCP access. Set it as a secret or in wrangler.jsonc vars.");
-  console.warn("[mcp] Operation attributed to admin via service-mode fallback (no userEmail threaded).");
-  return email;
-}
 
 /**
  * Check whether the caller has at least `required` permission on the session.
@@ -165,7 +147,7 @@ async function agentFetch(env: Env, sessionId: string, path: string, init?: Requ
   const headers = new Headers(init?.headers);
   headers.set("x-dodo-session-id", sessionId);
   headers.set("x-owner-email", email);
-  headers.set("x-dodo-mcp-depth", String(depth + 1));
+  propagateMcpDepth(headers, depth);
 
   // Inject gateway config for message/prompt routes
   if (path === "/message" || path === "/prompt") {
@@ -519,10 +501,6 @@ async function pollAndFinalize(env: Env, run: WorkerRunRecord, ownerEmail: strin
 
 function textResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
-}
-
-function errorResult(data: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }], isError: true };
 }
 
 async function jsonFetch(env: Env, fetcher: "user" | "shared" | "agent", path: string, opts?: { sessionId?: string; init?: RequestInit; depth?: number }): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: true }> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getAgentByName } from "agents";
 import { z } from "zod";
-import { getSharedIndexStub, getUserControlStub, isAdmin } from "./auth";
+import { getSharedIndexStub, getUserControlStub, isAdmin, resolveAdminEmail } from "./auth";
 import { log } from "./logger";
 import { messageLimiter, promptLimiter } from "./rate-limit";
 import { createDraftPrForRun, createGithubRepo } from "./github-pr";


### PR DESCRIPTION
## Summary
- Create `src/mcp-shared.ts` with `mcpUserEmail`, `errorResult`, and `propagateMcpDepth`
- Update `src/mcp.ts` and `src/mcp-codemode.ts` to import from the shared module
- No change to outbound MCP server behaviour or tool schemas

## Why
Both files exposed Dodo's API to MCP clients (full surface vs code-mode-minimal). Both maintained their own copies of identity resolution, error shaping, and depth propagation. Changes to auth had to land in two places. Per the `improve-codebase-architecture` audit.

## Divergences resolved
The two `mcpUserEmail` implementations were functionally identical except for their `console.warn` label (`[mcp]` vs `[mcp-codemode]`). The shared helper accepts an optional `label` parameter (default `"mcp"`) so both call sites retain their original prefix. `errorResult` and depth propagation were verbatim duplicates.

## Test plan
- `npm run typecheck` — clean
- `npm test` — clean (including `test/mcp-*.test.ts`, all 656 tests pass)
- `npm run lint` — clean