### PR TITLE
fix(a11y): replace strong[role=button] with native button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -624,7 +624,7 @@
       <div style="padding:10px 16px;border-bottom:1px solid var(--border);display:flex;justify-content:space-between;align-items:center;background:var(--panel);gap:8px">
         <div style="display:flex;align-items:center;min-width:0;flex:1">
           <span id="session-status-dot" class="status-dot idle" role="img" aria-label="Session status: idle"></span>
-          <strong id="session-title-display" style="cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0" onclick="renameSession()" title="Click to rename" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();renameSession()}">No session</strong>
+          <button id="session-title-display" style="cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;font-weight:700;font-size:inherit;font-family:inherit;background:none;border:none;padding:0;text-align:left;color:inherit" onclick="renameSession()" title="Click to rename">No session</button>
           <span id="session-id-display" style="font-size:11px;color:var(--muted);margin-left:8px;flex-shrink:0"></span>
           <span id="token-summary" class="token-summary" style="margin-left:8px;flex-shrink:0"></span>
           <span id="build-version" class="token-summary" style="margin-left:8px;flex-shrink:0"></span>


### PR DESCRIPTION
## What

Replace the `<strong id="session-title-display" role="button">` with a native `<button>` element.

## Why

The session title used a `<strong>` with `role="button"`, `tabindex="0"`, and a manual `onkeydown` handler to simulate button behavior. Per semantic HTML best practices (and the html skill rules):

- **Rule 6: Prefer native HTML behavior** — use `<button>` for actions
- **Rule 13: Links and Buttons Are Not Interchangeable** — never use a clickable non-interactive element instead of a button
- **Anti-pattern: using `div` for buttons or links** (applies to any non-interactive element repurposed as a button)

A native `<button>` gets keyboard interaction, focus styling, and ARIA semantics for free — no manual `tabindex`, `role`, or `onkeydown` needed.

## Test plan

- [ ] Click session title in header — rename dialog still opens
- [ ] Tab to session title — focus ring appears
- [ ] Press Enter/Space on focused title — rename dialog opens
- [ ] Visual appearance unchanged (font weight, color, layout)