### PR TITLE
refactor(subagent-runner): extract single runner for in-process + facet subagents

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -1,6 +1,5 @@
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { StateBackend } from "@cloudflare/shell";
-import { generateText, jsonSchema, stepCountIs, tool, zodSchema, type ModelMessage } from "ai";
+import { jsonSchema, tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { Workspace } from "@cloudflare/shell";
 import type { AttachmentRef } from "./attachments";
@@ -10,6 +9,18 @@ import { normalizePath } from "./paths";
 import { createBrowserTools } from "./browser/tools";
 import type { McpClient } from "./mcp-client";
 import { getKnownRepo, listKnownRepos, parseRemoteSpec } from "./repos";
+import {
+  buildProviderForModel,
+  capToolOutputs,
+  EXPLORE_MAX_STEPS,
+  EXPLORE_SYSTEM_PROMPT,
+  EXPLORE_TIMEOUT_MS,
+  resolveSubagentModel,
+  runSubagent,
+  TASK_MAX_STEPS,
+  TASK_SYSTEM_PROMPT,
+  TASK_TIMEOUT_MS,
+} from "./subagent-runner";
 import { createWorkspaceTools, createExecuteTool } from "./think-adapter";
 import { runTypecheck } from "./typecheck";
 import type { AppConfig, Env, TodoStore } from "./types";
@@ -106,130 +117,6 @@ interface BuildToolsOptions {
   };
 }
 
-// ─── Tool Output Caps (OpenCode Pattern #1) ───
-// Cap tool output AT THE TOOL LEVEL before it enters the AI SDK message history.
-// This is more effective than truncating in assembleContext/prepareStep because
-// the tokens never enter the step-level accumulation in the first place.
-
-/**
- * Per-tool output limits. Applied before results enter the AI SDK message
- * history — prevents large results from accumulating across multi-step loops.
- *
- * Note: Think's tools already have internal caps (read: 2000 lines,
- * find/grep: 200 results). These are stricter secondary caps that match
- * OpenCode's proven values. The read tool's internal 2000-line cap makes
- * an external cap redundant, so only entry-based caps are defined here.
- */
-const TOOL_OUTPUT_CAPS: Record<string, { maxLines?: number; maxBytes?: number; maxEntries?: number }> = {
-  grep:   { maxEntries: 100 },  // Think caps at 200; we cap at 100
-  find:   { maxEntries: 100 },  // Think caps at 200; we cap at 100
-  list:   { maxEntries: 100 },  // Think's list accepts a limit param; we cap the output
-  read:   { maxLines: 200 },    // Force the model to use offset/limit for large files.
-                                // Think caps at 2000 lines but that's ~60k tokens — too
-                                // much for discovery. 200 lines is enough for a preview;
-                                // the truncation hint tells the model to use offset/limit.
-  // codemode — 32 KB soft cap. codemode lets the model call arbitrary JS
-  // including fetch() against external APIs; without a cap, a single
-  // GitHub-API-style response can burn 200k+ input tokens. Enforced in
-  // capCodemodeResult() below because codemode's result shape is
-  // `{ code, result, logs? }` rather than the generic shapes handled by
-  // capResult(). Pairs with the `select` schema projection (described in
-  // the tool's prompt) so the model can pre-narrow before output hits here.
-  codemode: { maxBytes: 32_000 },
-  // write, edit, delete — already produce small output, no cap needed
-};
-
-/** Max bytes for a codemode `logs` field; kept separate from result. */
-const CODEMODE_LOGS_MAX_BYTES = 4_000;
-
-/**
- * Wrap a tool set to enforce per-tool output caps.
- * Each tool's execute function is intercepted: the result is serialized,
- * checked against its cap, and truncated with an actionable hint if exceeded.
- */
-export function capToolOutputs(tools: Record<string, AnyTool>): Record<string, AnyTool> {
-  const wrapped: Record<string, AnyTool> = {};
-  for (const [name, t] of Object.entries(tools)) {
-    const caps = TOOL_OUTPUT_CAPS[name];
-    if (!caps) {
-      wrapped[name] = t;
-      continue;
-    }
-    // Clone the tool with a wrapped execute
-    const original = t as AnyTool & { execute?: (...args: unknown[]) => unknown };
-    if (!original.execute) {
-      wrapped[name] = t;
-      continue;
-    }
-    const origExecute = original.execute;
-    wrapped[name] = {
-      ...original,
-      execute: async (...args: unknown[]) => {
-        const result = await (origExecute as (...a: unknown[]) => Promise<unknown>)(...args);
-        return capResult(name, result, caps);
-      },
-    } as AnyTool;
-  }
-  return wrapped;
-}
-
-/** Apply output caps to a single tool result. */
-function capResult(
-  toolName: string,
-  result: unknown,
-  caps: { maxLines?: number; maxBytes?: number; maxEntries?: number },
-): unknown {
-  if (result === null || result === undefined) return result;
-
-  // Handle structured results (objects with entries arrays — list, find, grep)
-  if (typeof result === "object" && !Array.isArray(result)) {
-    const obj = result as Record<string, unknown>;
-
-    // Cap entries arrays (list, find, grep return { entries: [...] } or { matches: [...] })
-    if (caps.maxEntries) {
-      for (const key of ["entries", "matches", "files"]) {
-        if (Array.isArray(obj[key]) && (obj[key] as unknown[]).length > caps.maxEntries) {
-          const original = obj[key] as unknown[];
-          const capped = original.slice(0, caps.maxEntries);
-          return {
-            ...obj,
-            [key]: capped,
-            _truncated: `Showing ${caps.maxEntries} of ${original.length} results. Use a more specific pattern to narrow results.`,
-          };
-        }
-      }
-    }
-
-    // Cap text content in read results
-    if (caps.maxLines || caps.maxBytes) {
-      // The read tool returns { content: string, ... } or just a string
-      const content = typeof obj.content === "string" ? obj.content : null;
-      if (content) {
-        const capped = capText(content, caps.maxLines ?? Infinity, caps.maxBytes ?? Infinity);
-        if (capped !== content) {
-          const lines = content.split("\n").length;
-          return {
-            ...obj,
-            content: capped,
-            _truncated: `Output capped. Showing partial content of ${lines} total lines. Use read with offset/limit to view specific sections.`,
-          };
-        }
-      }
-    }
-  }
-
-  // Handle plain string results
-  if (typeof result === "string" && (caps.maxLines || caps.maxBytes)) {
-    const capped = capText(result, caps.maxLines ?? Infinity, caps.maxBytes ?? Infinity);
-    if (capped !== result) {
-      const lines = result.split("\n").length;
-      return capped + `\n\n[Output capped. ${lines} total lines. Use read with offset/limit to view specific sections.]`;
-    }
-  }
-
-  return result;
-}
-
 /**
  * Middle-truncate a string to fit within a byte budget. Keeps head and tail
  * so both the shape of the value and its end (often the most recent /
@@ -259,6 +146,9 @@ function middleTruncate(text: string, maxBytes: number): string {
  * The `code` field is left untouched — it's typically small, and we want the
  * model to be able to diff what it sent vs what came back.
  */
+/** Max bytes for a codemode `logs` field; kept separate from result. */
+const CODEMODE_LOGS_MAX_BYTES = 4_000;
+
 export function capCodemodeResult(result: unknown, maxBytes: number): unknown {
   if (!result || typeof result !== "object") return result;
   const obj = result as { code?: unknown; result?: unknown; logs?: unknown };
@@ -334,337 +224,8 @@ function getByPath(value: unknown, path: string): unknown {
   return current;
 }
 
-/** Truncate text by line count and byte size, keeping the head. */
-function capText(text: string, maxLines: number, maxBytes: number): string {
-  const lines = text.split("\n");
-  if (lines.length <= maxLines && text.length <= maxBytes) return text;
-
-  const kept: string[] = [];
-  let bytes = 0;
-  for (let i = 0; i < lines.length && i < maxLines; i++) {
-    const line = lines[i];
-    if (bytes + line.length + 1 > maxBytes) break;
-    kept.push(line);
-    bytes += line.length + 1;
-  }
-  return kept.join("\n");
-}
-
-function trimBaseUrl(url: string): string {
-  return url.endsWith("/") ? url.slice(0, -1) : url;
-}
-
-// ─── Subagent message-history pruning ───
-// Tool-level output caps (capToolOutputs above) bound the size of ANY single
-// tool result. But inside a multi-step subagent run, every prior tool result
-// stays pinned in the `messages` array and gets re-fed to the model every step.
-// A 12-step explore that reads five 200-line snippets still ships ~50k tokens
-// of stale tool output at step 12 — because steps 1-11 are still present.
-//
-// Observed in the 2026-04-24 prod A/B: a single explore facet accumulated
-// ~301k input tokens across 12 steps, within shouting distance of Haiku's
-// 200k window. No single step was over the per-tool cap; the sum was.
-//
-// `pruneSubagentHistory` plugs into `generateText`'s `prepareStep` callback.
-// It keeps:
-//   - the system message (injected by generateText, not in our `messages`)
-//   - the initial user message (the query/prompt)
-//   - the most recent N assistant+tool_result pairs
-// and replaces the dropped middle with a single marker message so the model
-// knows history was compacted, not corrupted.
-//
-// N defaults to 4. That's aggressive — two full tool-call cycles in working
-// memory plus the current turn. Subagents are supposed to do ONE bounded
-// thing; they don't need long-term conversational context. If the model
-// needed information from an earlier step, it should have summarised it
-// into its own reasoning before now.
-
-/**
- * Keep this many trailing message groups (each group = one assistant msg
- * plus any tool_result messages tied to it). Chosen empirically: smaller
- * values risk dropping useful context the model hasn't condensed yet;
- * larger values defeat the point. 4 is enough for the model to remember
- * its last ~2 tool-call cycles plus the current turn.
- */
-const SUBAGENT_MSG_WINDOW = 4;
-
-/**
- * Compact tool-result marker used when we drop the middle of the message
- * history. Surfaces a rough count so the model can self-explain if asked.
- */
-function makePruneMarker(droppedCount: number): ModelMessage {
-  return {
-    role: "user",
-    content: `[system: ${droppedCount} earlier assistant/tool messages were pruned to keep your input token count bounded. If you need information from those steps, call the relevant tool again — don't try to reconstruct the content.]`,
-  };
-}
-
-/**
- * Return a pruned copy of `messages` keeping the initial user prompt and the
- * most recent `windowSize` assistant+tool_result groups. Stable when the
- * history is already short enough.
- *
- * Intended for use inside `generateText({ prepareStep })`.
- */
-export function pruneSubagentHistory(
-  messages: Array<ModelMessage>,
-  windowSize: number = SUBAGENT_MSG_WINDOW,
-): Array<ModelMessage> {
-  if (messages.length <= windowSize + 1) return messages;
-
-  // Find the first user message — this is the original query we must preserve
-  // across pruning so the model retains its goal.
-  const firstUserIdx = messages.findIndex((m) => m.role === "user");
-  if (firstUserIdx < 0) return messages; // defensive — shouldn't happen
-
-  // Walk from the end of the list backwards and group: every assistant
-  // message and the tool_result messages that follow it are one "group".
-  // We keep the last `windowSize` groups.
-  const groups: Array<{ start: number; end: number }> = [];
-  let cursor = messages.length;
-  while (cursor > firstUserIdx + 1 && groups.length < windowSize) {
-    const end = cursor;
-    let start = cursor - 1;
-    // Walk backwards through any leading non-assistant messages (tool results)
-    // until we find the assistant message that emitted them.
-    while (start > firstUserIdx + 1 && messages[start].role !== "assistant") {
-      start--;
-    }
-    groups.unshift({ start, end });
-    cursor = start;
-  }
-
-  if (groups.length === 0) return messages;
-
-  // Keep: [0 .. firstUserIdx], marker, messages[groups[0].start ..]
-  const head = messages.slice(0, firstUserIdx + 1);
-  const tailStart = groups[0].start;
-  const dropped = tailStart - (firstUserIdx + 1);
-  if (dropped <= 0) return messages;
-  const tail = messages.slice(tailStart);
-  return [...head, makePruneMarker(dropped), ...tail];
-}
-
-/**
- * Convenience: build a `prepareStep` callback suitable for passing into
- * `generateText` in both explore and task subagent call sites. Returns a
- * message override only when pruning actually happens.
- */
-export function subagentPrepareStep(options?: { windowSize?: number }) {
-  const windowSize = options?.windowSize ?? SUBAGENT_MSG_WINDOW;
-  return ({ messages }: { messages: Array<ModelMessage> }) => {
-    const pruned = pruneSubagentHistory(messages, windowSize);
-    return pruned === messages ? {} : { messages: pruned };
-  };
-}
-
-/**
- * Add Anthropic prompt-caching cache_control markers to an OpenAI-compatible
- * request body. Invoked by @ai-sdk/openai-compatible as transformRequestBody,
- * so this runs once per outbound request (per call to streamText / generateText).
- *
- * Strategy — place markers at the boundaries Anthropic expects:
- *   1. System prompt   → cache (static per session after turn 1)
- *   2. Tool definitions → cache (stable per session)
- *   3. Last user message → cache (reuses cached context on retries)
- *
- * Anthropic allows up to 4 cache_control markers per request. We use 3 to
- * leave one spare for future extensions (e.g. caching a compaction summary).
- *
- * The OpenAI-compatible wire format allows system to be a string; when
- * routed to Anthropic the gateway re-shapes it. We upgrade to the Anthropic
- * array-of-content-blocks shape at the wire level — most gateways that route
- * to Anthropic pass this through unchanged; those that don't strip the
- * cache_control field silently (no error).
- *
- * All modifications are idempotent: if cache_control markers already exist,
- * we leave them alone.
- */
-export function addAnthropicCacheMarkers(body: Record<string, unknown>): Record<string, unknown> {
-  // No-op for non-Anthropic requests. The transform is installed on every
-  // provider instance so calls that override the session model (e.g. the
-  // compaction step pinned to claude-haiku-4-5) get caching too. Detect
-  // Anthropic by checking the outbound model field — it's already been
-  // translated to the wire format (e.g. "anthropic/claude-opus-4-7") by
-  // the time transformRequestBody runs.
-  const modelId = typeof body.model === "string" ? body.model : "";
-  if (!modelId.startsWith("anthropic/") && !modelId.startsWith("claude-")) {
-    return body;
-  }
-
-  // Shallow clone so we don't mutate the caller's object
-  const out: Record<string, unknown> = { ...body };
-
-  // 1. System prompt — upgrade string → array with cache_control
-  if (typeof out.system === "string" && out.system.length > 0) {
-    out.system = [
-      { type: "text", text: out.system, cache_control: { type: "ephemeral" } },
-    ];
-  } else if (Array.isArray(out.system) && out.system.length > 0) {
-    // Already array form — mark the last block if none has cache_control yet
-    const hasMarker = out.system.some(
-      (block) => block && typeof block === "object" && "cache_control" in (block as object),
-    );
-    if (!hasMarker) {
-      const last = out.system[out.system.length - 1];
-      if (last && typeof last === "object") {
-        out.system = [
-          ...out.system.slice(0, -1),
-          { ...(last as object), cache_control: { type: "ephemeral" } },
-        ];
-      }
-    }
-  }
-
-  // 2. Tools — attach cache_control to the last tool definition so the
-  //    whole tool-schema block is cached. Tools are stable per session, so
-  //    this produces a reliable cache hit on every subsequent step.
-  if (Array.isArray(out.tools) && out.tools.length > 0) {
-    const tools = out.tools as unknown[];
-    const hasMarker = tools.some(
-      (t) => t && typeof t === "object" && "cache_control" in (t as object),
-    );
-    if (!hasMarker) {
-      const lastIdx = tools.length - 1;
-      const last = tools[lastIdx];
-      if (last && typeof last === "object") {
-        out.tools = [
-          ...tools.slice(0, lastIdx),
-          { ...(last as object), cache_control: { type: "ephemeral" } },
-        ];
-      }
-    }
-  }
-
-  // 3. Last user message — place a cache marker so that between-step
-  //    reruns can reuse the cached input. Conservative: only upgrade if
-  //    the content is a string (don't touch multimodal arrays to avoid
-  //    accidentally breaking image-bearing messages).
-  if (Array.isArray(out.messages) && out.messages.length > 0) {
-    const messages = out.messages as Array<Record<string, unknown>>;
-    // Walk from the end to find the last user message
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg?.role !== "user") continue;
-      if (typeof msg.content === "string" && msg.content.length > 0) {
-        const updated: Record<string, unknown> = {
-          ...msg,
-          content: [
-            {
-              type: "text",
-              text: msg.content,
-              cache_control: { type: "ephemeral" },
-            },
-          ],
-        };
-        out.messages = [...messages.slice(0, i), updated, ...messages.slice(i + 1)];
-      }
-      break;
-    }
-  }
-
-  return out;
-}
-
-/** Some model IDs need rewriting before they're sent to the upstream gateway.
- *  - Workers AI models (`@cf/…`) need the `workers-ai/` prefix per AI Gateway
- *    unified-API docs: https://developers.cloudflare.com/ai-gateway/chat-completion/
- *    They only work when the active gateway is `ai-gateway`.
- *  Returns the wire-format model ID, or throws if the combination is invalid. */
-export function resolveWireModelId(modelId: string, activeGateway: "opencode" | "ai-gateway"): string {
-  if (modelId.startsWith("@cf/")) {
-    if (activeGateway !== "ai-gateway") {
-      throw new Error(
-        `Workers AI model "${modelId}" requires the AI Gateway. ` +
-        `Switch gateway to "ai-gateway" in Settings (or via update_config).`,
-      );
-    }
-    return `workers-ai/${modelId}`;
-  }
-  return modelId;
-}
-
-/**
- * Pick the right gateway for a given model ID.
- *
- *  - `@cf/*` (Workers AI) → always ai-gateway
- *  - Everything else → respect whatever `config.activeGateway` says
- *
- * This lets a subagent run on a Workers AI model (e.g. Kimi K2.6) even if
- * the main session uses the opencode gateway. Without this, asking Kimi
- * to do explore work from an opencode-gateway session would fail because
- * the provider baseURL would be wrong.
- */
-function resolveGatewayForModel(
-  modelId: string,
-  mainGateway: "opencode" | "ai-gateway",
-): "opencode" | "ai-gateway" {
-  if (modelId.startsWith("@cf/")) return "ai-gateway";
-  return mainGateway;
-}
-
 export function buildProvider(config: AppConfig, env: Env) {
   return buildProviderForModel(config.model, config, env);
-}
-
-/**
- * Build a provider for a specific model — picks the right gateway and
- * base URL even if that differs from the session's main gateway. Used by
- * subagents that run on a cheaper/different model than the main session.
- */
-export function buildProviderForModel(modelId: string, config: AppConfig, env: Env) {
-  const effectiveGateway = resolveGatewayForModel(modelId, config.activeGateway);
-  const isOpencode = effectiveGateway === "opencode";
-  const baseURL = isOpencode
-    ? `${trimBaseUrl(config.opencodeBaseURL)}`
-    : `${trimBaseUrl(config.aiGatewayBaseURL)}`;
-
-  const headers: Record<string, string> = isOpencode
-    ? { "cf-access-token": env.OPENCODE_GATEWAY_TOKEN ?? "" }
-    : {
-        // AI Gateway unified API: auth with `cf-aig-authorization` bearer.
-        // We keep `x-api-key` for back-compat with existing deployments.
-        "cf-aig-authorization": `Bearer ${env.AI_GATEWAY_KEY ?? ""}`,
-        "x-api-key": env.AI_GATEWAY_KEY ?? "",
-      };
-
-  // Anthropic prompt caching. The transform checks the outbound model per
-  // request and only acts when the wire-format model ID starts with
-  // "anthropic/" (or "claude-"). Always installing it ensures we still get
-  // caching on calls that use a different model than the session default —
-  // most importantly the compaction step, which hardcodes
-  // anthropic/claude-haiku-4-5 regardless of the session model.
-  // For non-Anthropic requests the transform is a no-op.
-  const provider = createOpenAICompatible({
-    baseURL,
-    headers,
-    includeUsage: true,
-    name: effectiveGateway,
-    transformRequestBody: addAnthropicCacheMarkers,
-  });
-
-  // Wrap `chatModel` / `languageModel` / the callable provider so callers can pass
-  // the user-facing id (e.g. `@cf/moonshotai/kimi-k2.6`) and we translate it to the
-  // wire format (`workers-ai/@cf/moonshotai/kimi-k2.6`) exactly once, at the edge.
-  // Use the *effective* gateway (the one we actually picked for this provider)
-  // so @cf/* models don't trip resolveWireModelId's activeGateway check when
-  // the main session is on opencode but the subagent wants Workers AI.
-  const translate = (m: string) => resolveWireModelId(m, effectiveGateway);
-  const originalChatModel = provider.chatModel.bind(provider);
-  const originalLanguageModel = provider.languageModel.bind(provider);
-
-  return new Proxy(provider, {
-    // Intercept `provider("model-id")` (the callable form).
-    apply(_target, _thisArg, args: [string, ...unknown[]]) {
-      const [modelId, ...rest] = args;
-      return originalLanguageModel(translate(modelId), ...(rest as []));
-    },
-    get(target, prop, receiver) {
-      if (prop === "chatModel") return (modelId: string) => originalChatModel(translate(modelId));
-      if (prop === "languageModel") return (modelId: string, cfg?: unknown) => originalLanguageModel(translate(modelId), cfg as Parameters<typeof originalLanguageModel>[1]);
-      return Reflect.get(target, prop, receiver);
-    },
-  });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1037,112 +598,6 @@ function buildGitTools(
   };
 }
 
-// ─── Explore Subagent (Phase 3) ───
-// Offloads open-ended file search to a worker generateText call with its own
-// context window. Returns a compact summary (~500-1000 tokens) instead of
-// raw file contents (~5000-20000 tokens), saving 5-20× tokens per search.
-
-/** Max steps for the explore subagent.
- *  History:
- *   - Bumped 5 → 12 after the 2026-04-24 demo sessions
- *     (`877cefcc`, `197cc126`, `fdad8393`) showed 5 steps was routinely
- *     consumed by tool-calling before the model got a chance to summarise.
- *   - Bumped 12 → 16 after a 2026-04-25 prod A/B surfaced the same
- *     exhaustion pattern: multiple facet runs hit step 12 with ~25k of
- *     accumulated grep/read context and emitted empty summaries, forcing
- *     the parent (Opus) to retry — doubling the tokens that were supposed
- *     to be saved. 16 + the explicit "reserve 2 for summary" rule in the
- *     system prompt hits the same observed tool-call volume without
- *     starving the summary. */
-export const EXPLORE_MAX_STEPS = 16;
-
-export const EXPLORE_SYSTEM_PROMPT = [
-  "You are a search assistant. Your job is to find files and code relevant to the user's query.",
-  "",
-  "## Rules",
-  "- Use grep, find, list, and read to search the workspace.",
-  "- Be thorough: try multiple search terms if the first doesn't find results.",
-  `- You have a hard budget of ${EXPLORE_MAX_STEPS} steps. **Reserve the last 2 steps for your summary** — at step ${EXPLORE_MAX_STEPS - 2} or earlier, stop calling tools and write your findings.`,
-  "- Return a concise summary when done: file paths, relevant line numbers, and key observations.",
-  "- Do NOT return full file contents — only the relevant snippets (max 10 lines per file).",
-  "- If you find too many results, narrow your search with more specific patterns.",
-  "- Focus on answering the user's specific question, not cataloguing everything.",
-  "- Emitting SOME summary beats hitting the step limit silent. A rough summary is recoverable; no summary wastes the caller's retry budget.",
-].join("\n");
-
-/** Cheap model for the explore subagent, keyed by provider prefix.
- *  Falls back to the main model if no match (still works, just costs more). */
-const EXPLORE_MODELS: Record<string, string> = {
-  "anthropic/": "anthropic/claude-haiku-4-5",
-  "openai/": "openai/gpt-4.1-mini",
-  "google/": "google/gemini-2.5-flash",
-  "deepseek/": "deepseek/deepseek-chat",
-};
-export function getExploreModel(mainModel: string): string {
-  for (const [prefix, model] of Object.entries(EXPLORE_MODELS)) {
-    if (mainModel.startsWith(prefix)) return model;
-  }
-  return mainModel; // fallback: use the main model itself
-}
-
-/** Timeout for the explore subagent (ms). Prevents indefinite blocking. */
-export const EXPLORE_TIMEOUT_MS = 60_000;
-
-/** Max steps for the generic task subagent.
- *  Bumped 15 → 20 alongside EXPLORE_MAX_STEPS 12 → 16 on 2026-04-25
- *  to leave room for the "reserve 2 for summary" pacing rule in
- *  TASK_SYSTEM_PROMPT. Task is write-capable and typically uses more
- *  tool calls per run than explore. */
-export const TASK_MAX_STEPS = 20;
-
-/** Timeout for the generic task subagent (ms).
- *  Raised to 600s when the task runs inside a facet — the facet has its
- *  own DO request lifetime and isn't bound by the parent's turn budget. */
-export const TASK_TIMEOUT_MS = 180_000;
-export const TASK_FACET_TIMEOUT_MS = 600_000;
-
-export const TASK_SYSTEM_PROMPT = [
-  "You are a focused subagent dispatched by the main Dodo agent to handle one bounded task.",
-  "",
-  "## Rules",
-  "- You have a subset of the main agent's tools. Use them to complete the task and ONLY the task.",
-  "- Do not ask clarifying questions — make a best-effort attempt with the info given.",
-  `- You have a hard budget of ${TASK_MAX_STEPS} steps. **Reserve the last 2 steps for your summary** — at step ${TASK_MAX_STEPS - 2} or earlier, stop calling tools and write your summary.`,
-  "- Return a compact text summary when done. Include: what you did, paths/line numbers touched, test results if any.",
-  "- Do NOT dump large tool outputs into your final message — summarize in 5-15 lines.",
-  "- If you hit your step budget without finishing, report what was done and what remains. Your caller will retry.",
-  "- Emitting SOME summary beats hitting the step limit silent. A rough summary is recoverable; no summary wastes the caller's retry budget.",
-].join("\n");
-
-/**
- * Pick the model a subagent should use.
- *
- * Precedence:
- *   1. Per-call override — `args.model` on the tool call
- *   2. Per-session default — `config.exploreModel` / `config.taskModel`
- *      (sourced from DodoConfig, ultimately from the env defaults
- *       DEFAULT_EXPLORE_MODEL / DEFAULT_TASK_MODEL on wrangler.jsonc)
- *   3. Built-in heuristic — `getExploreModel(config.model)` which picks a
- *      cheap model by provider family, falling back to the main model itself
- *
- * Each level is only used if the one above is unset/blank, so users can
- * configure globally but still override on a hot path.
- */
-export function resolveSubagentModel(
-  args: Record<string, unknown>,
-  sessionDefault: string | undefined,
-  mainModel: string,
-): string {
-  const rawArgModel = args.model;
-  if (typeof rawArgModel === "string" && rawArgModel.trim().length > 0) {
-    return rawArgModel.trim();
-  }
-  if (typeof sessionDefault === "string" && sessionDefault.trim().length > 0) {
-    return sessionDefault.trim();
-  }
-  return getExploreModel(mainModel);
-}
-
 /**
  * Build a subagent tool with a configurable name, description, system prompt,
  * tool subset, and step/timeout budgets. Both `explore` and `task` are
@@ -1212,56 +667,30 @@ function buildSubagentTool(spec: {
     inputSchema: spec.inputSchema,
     execute: async (args: Record<string, unknown>) => {
       const modelId = resolveSubagentModel(args, spec.sessionDefaultModel, spec.config.model);
-      const provider = buildProviderForModel(modelId, spec.config, spec.env);
-      const model = provider.chatModel(modelId);
       const userMessage = spec.getUserMessage(args);
 
       try {
-        const result = await generateText({
-          model,
-          system: spec.systemPrompt,
-          messages: [{ role: "user" as const, content: userMessage }],
-          tools: spec.getTools(),
-          stopWhen: stepCountIs(spec.maxSteps),
-          // Bumped from 2000 → 4000. The explore/task subagents frequently
-          // summarize 5-10 files' worth of findings; 2000 tokens was clipping
-          // the summary mid-sentence after the model ran its tool budget.
-          // 4000 still small enough to keep the subagent's turn compact.
-          maxOutputTokens: 4000,
-          // Prune older assistant/tool message groups between steps so a long
-          // investigation doesn't ship its entire tool-result history back to
-          // the model on every call. Tool-level caps bound single results; this
-          // bounds the sum across steps.
-          prepareStep: subagentPrepareStep(),
-          abortSignal: AbortSignal.timeout(spec.timeoutMs),
+        const result = await runSubagent({
+          kind: spec.name.toLowerCase() as "explore" | "task",
+          prompt: userMessage,
+          model: modelId,
+          config: spec.config,
+          toolset: spec.getTools(),
+          systemPrompt: spec.systemPrompt,
+          maxSteps: spec.maxSteps,
+          timeoutMs: spec.timeoutMs,
+          env: spec.env,
         });
 
-        const summary = result.text;
-        const steps = result.steps.length;
-        const toolCalls = result.steps.flatMap((s) =>
-          (s.toolCalls ?? []).map((tc) => tc.toolName),
-        );
-        // Sum per-step usage into a single subagent cost line. Surfacing
-        // this matters for observability — "explore used 40k tokens" is a
-        // cost the parent can't see otherwise since the subagent's LLM
-        // calls don't touch the parent's message_metadata totals.
-        const totalInput = result.steps.reduce(
-          (sum, s) => sum + (s.usage?.inputTokens ?? 0),
-          0,
-        );
-        const totalOutput = result.steps.reduce(
-          (sum, s) => sum + (s.usage?.outputTokens ?? 0),
-          0,
-        );
-        const usageLine = totalInput > 0 || totalOutput > 0
-          ? `**Tokens:** ${totalInput} in / ${totalOutput} out | `
+        const usageLine = result.tokenInput > 0 || result.tokenOutput > 0
+          ? `**Tokens:** ${result.tokenInput} in / ${result.tokenOutput} out | `
           : "";
 
         return [
           `## ${spec.name} results (model: ${modelId})`,
-          `${usageLine}**Steps:** ${steps} | **Tools used:** ${toolCalls.join(", ") || "none"}`,
+          `${usageLine}**Steps:** ${result.steps} | **Tools used:** ${result.toolCalls.join(", ") || "none"}`,
           "",
-          summary || "(No output — subagent ran its tool budget without emitting a summary. Try a narrower query or a higher-capability model via the `model` arg.)",
+          result.finalText || "(No output — subagent ran its tool budget without emitting a summary. Try a narrower query or a higher-capability model via the `model` arg.)",
         ].filter(Boolean).join("\n");
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -1735,8 +1164,7 @@ function buildTools(
     // schema projection. Without this, a single `await fetch(...)` against
     // a large API in codemode can one-shot the input-token budget before
     // any downstream safeguard can react (see dodo session 56a7a597).
-    const caps = TOOL_OUTPUT_CAPS.codemode ?? { maxBytes: 32_000 };
-    const maxBytes = caps.maxBytes ?? 32_000;
+    const maxBytes = 32_000;
 
     const originalExecute = (codemodeTool as AnyTool).execute as
       | ((args: unknown, ...rest: unknown[]) => Promise<unknown>)

--- a/src/explore-agent.ts
+++ b/src/explore-agent.ts
@@ -1,20 +1,17 @@
 import { Agent, getAgentByName } from "agents";
-import { generateText, stepCountIs } from "ai";
 import {
   createReadTool,
   createListTool,
   createFindTool,
   createGrepTool,
-} from "@cloudflare/think/tools/workspace";
+} from "./think-adapter";
 import {
-  buildProviderForModel,
-  capToolOutputs,
+  runSubagent,
   EXPLORE_SYSTEM_PROMPT,
   EXPLORE_MAX_STEPS,
   EXPLORE_TIMEOUT_MS,
   resolveSubagentModel,
-  subagentPrepareStep,
-} from "./agentic";
+} from "./subagent-runner";
 import type { AppConfig, Env } from "./types";
 import type { CodingAgent } from "./coding-agent";
 
@@ -154,8 +151,6 @@ export class ExploreAgent extends Agent<Env> {
     const parentSessionId = opts.parentSessionId;
 
     const modelId = resolveSubagentModel({ model: opts.model }, config.exploreModel, config.model);
-    const provider = buildProviderForModel(modelId, config, this.env);
-    const model = provider.chatModel(modelId);
 
     // Get the parent stub and build read-only workspace tools that proxy
     // through the parent's workspace — see `CodingAgent.facetReadFile`.
@@ -164,7 +159,7 @@ export class ExploreAgent extends Agent<Env> {
       parentSessionId,
     )) as unknown as ParentStub;
 
-    const readOnlyTools = capToolOutputs({
+    const readOnlyTools = {
       read: createReadTool({
         ops: {
           readFile: (path: string) => parent.facetReadFile(path),
@@ -188,7 +183,7 @@ export class ExploreAgent extends Agent<Env> {
           readFile: (path: string) => parent.facetReadFile(path),
         },
       }),
-    });
+    };
 
     const scope = opts.scope ? `\n\nSearch scope: ${opts.scope}` : "";
     const userMessage = `${opts.q}${scope}`;
@@ -196,43 +191,28 @@ export class ExploreAgent extends Agent<Env> {
     this.recordTranscript("user", userMessage, { model: modelId });
 
     try {
-      const result = await generateText({
-        model,
-        system: EXPLORE_SYSTEM_PROMPT,
-        messages: [{ role: "user" as const, content: userMessage }],
-        tools: readOnlyTools,
-        stopWhen: stepCountIs(EXPLORE_MAX_STEPS),
-        maxOutputTokens: 4000,
-        // See `subagentPrepareStep` in agentic.ts — prunes tool-result
-        // accumulation across steps so a 16-step run doesn't ship ~300k
-        // tokens of stale context back to the model on every call.
-        prepareStep: subagentPrepareStep(),
-        abortSignal: AbortSignal.timeout(EXPLORE_TIMEOUT_MS),
+      const result = await runSubagent({
+        kind: "explore",
+        prompt: userMessage,
+        model: modelId,
+        config,
+        toolset: readOnlyTools,
+        systemPrompt: EXPLORE_SYSTEM_PROMPT,
+        maxSteps: EXPLORE_MAX_STEPS,
+        timeoutMs: EXPLORE_TIMEOUT_MS,
+        env: this.env,
       });
 
-      const summary = result.text;
-      const steps = result.steps.length;
-      const toolCalls = result.steps.flatMap((s) =>
-        (s.toolCalls ?? []).map((tc) => tc.toolName),
-      );
-      const totalInput = result.steps.reduce(
-        (sum, s) => sum + (s.usage?.inputTokens ?? 0),
-        0,
-      );
-      const totalOutput = result.steps.reduce(
-        (sum, s) => sum + (s.usage?.outputTokens ?? 0),
-        0,
-      );
       const usageLine =
-        totalInput > 0 || totalOutput > 0
-          ? `**Tokens:** ${totalInput} in / ${totalOutput} out | `
+        result.tokenInput > 0 || result.tokenOutput > 0
+          ? `**Tokens:** ${result.tokenInput} in / ${result.tokenOutput} out | `
           : "";
 
       const formatted = [
         `## Explore results (model: ${modelId}) [facet: ${this.name}]`,
-        `${usageLine}**Steps:** ${steps} | **Tools used:** ${toolCalls.join(", ") || "none"}`,
+        `${usageLine}**Steps:** ${result.steps} | **Tools used:** ${result.toolCalls.join(", ") || "none"}`,
         "",
-        summary ||
+        result.finalText ||
           "(No output — subagent ran its tool budget without emitting a summary. Try a narrower query or a higher-capability model via the `model` arg.)",
       ]
         .filter(Boolean)
@@ -240,16 +220,16 @@ export class ExploreAgent extends Agent<Env> {
 
       this.recordTranscript("assistant", formatted, {
         model: modelId,
-        tokenInput: totalInput,
-        tokenOutput: totalOutput,
+        tokenInput: result.tokenInput,
+        tokenOutput: result.tokenOutput,
       });
 
       return {
         ok: true,
         facetName: this.name,
         summary: formatted,
-        tokenInput: totalInput,
-        tokenOutput: totalOutput,
+        tokenInput: result.tokenInput,
+        tokenOutput: result.tokenOutput,
       };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/subagent-runner.ts
+++ b/src/subagent-runner.ts
@@ -1,0 +1,544 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText, stepCountIs, type ModelMessage, type ToolSet } from "ai";
+import type { AppConfig, Env } from "./types";
+
+// ─── Tool Output Caps (OpenCode Pattern #1) ───
+// Cap tool output AT THE TOOL LEVEL before it enters the AI SDK message history.
+
+const TOOL_OUTPUT_CAPS: Record<string, { maxLines?: number; maxBytes?: number; maxEntries?: number }> = {
+  grep:   { maxEntries: 100 },
+  find:   { maxEntries: 100 },
+  list:   { maxEntries: 100 },
+  read:   { maxLines: 200 },
+  codemode: { maxBytes: 32_000 },
+};
+
+/** Max bytes for a codemode `logs` field; kept separate from result. */
+const CODEMODE_LOGS_MAX_BYTES = 4_000;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyTool = any;
+
+export function capToolOutputs(tools: Record<string, AnyTool>): Record<string, AnyTool> {
+  const wrapped: Record<string, AnyTool> = {};
+  for (const [name, t] of Object.entries(tools)) {
+    const caps = TOOL_OUTPUT_CAPS[name];
+    if (!caps) {
+      wrapped[name] = t;
+      continue;
+    }
+    const original = t as AnyTool & { execute?: (...args: unknown[]) => unknown };
+    if (!original.execute) {
+      wrapped[name] = t;
+      continue;
+    }
+    const origExecute = original.execute;
+    wrapped[name] = {
+      ...original,
+      execute: async (...args: unknown[]) => {
+        const result = await (origExecute as (...a: unknown[]) => Promise<unknown>)(...args);
+        return capResult(name, result, caps);
+      },
+    } as AnyTool;
+  }
+  return wrapped;
+}
+
+function capResult(
+  toolName: string,
+  result: unknown,
+  caps: { maxLines?: number; maxBytes?: number; maxEntries?: number },
+): unknown {
+  if (result === null || result === undefined) return result;
+
+  if (typeof result === "object" && !Array.isArray(result)) {
+    const obj = result as Record<string, unknown>;
+
+    if (caps.maxEntries) {
+      for (const key of ["entries", "matches", "files"]) {
+        if (Array.isArray(obj[key]) && (obj[key] as unknown[]).length > caps.maxEntries) {
+          const original = obj[key] as unknown[];
+          const capped = original.slice(0, caps.maxEntries);
+          return {
+            ...obj,
+            [key]: capped,
+            _truncated: `Showing ${caps.maxEntries} of ${original.length} results. Use a more specific pattern to narrow results.`,
+          };
+        }
+      }
+    }
+
+    if (caps.maxLines || caps.maxBytes) {
+      const content = typeof obj.content === "string" ? obj.content : null;
+      if (content) {
+        const capped = capText(content, caps.maxLines ?? Infinity, caps.maxBytes ?? Infinity);
+        if (capped !== content) {
+          const lines = content.split("\n").length;
+          return {
+            ...obj,
+            content: capped,
+            _truncated: `Output capped. Showing partial content of ${lines} total lines. Use read with offset/limit to view specific sections.`,
+          };
+        }
+      }
+    }
+  }
+
+  if (typeof result === "string" && (caps.maxLines || caps.maxBytes)) {
+    const capped = capText(result, caps.maxLines ?? Infinity, caps.maxBytes ?? Infinity);
+    if (capped !== result) {
+      const lines = result.split("\n").length;
+      return capped + `\n\n[Output capped. ${lines} total lines. Use read with offset/limit to view specific sections.]`;
+    }
+  }
+
+  return result;
+}
+
+function middleTruncate(text: string, maxBytes: number): string {
+  if (text.length <= maxBytes) return text;
+  const marker = "\n[... truncated %d bytes. Pass `select` to codemode to project only the fields you need. ...]\n";
+  const overhead = marker.length + 12;
+  const headBudget = Math.floor((maxBytes - overhead) * 0.6);
+  const tailBudget = Math.floor((maxBytes - overhead) * 0.4);
+  if (headBudget <= 0 || tailBudget <= 0) return text.slice(0, maxBytes);
+  const head = text.slice(0, headBudget);
+  const tail = text.slice(-tailBudget);
+  const dropped = text.length - headBudget - tailBudget;
+  return `${head}${marker.replace("%d", String(dropped))}${tail}`;
+}
+
+export function capCodemodeResult(result: unknown, maxBytes: number): unknown {
+  if (!result || typeof result !== "object") return result;
+  const obj = result as { code?: unknown; result?: unknown; logs?: unknown };
+  const out: Record<string, unknown> = { ...obj };
+
+  if (obj.result !== undefined) {
+    let serialized: string;
+    try {
+      serialized = typeof obj.result === "string" ? obj.result : JSON.stringify(obj.result);
+    } catch {
+      serialized = String(obj.result);
+    }
+    if (serialized.length > maxBytes) {
+      out.result = middleTruncate(serialized, maxBytes);
+      out._truncated = `codemode result exceeded ${maxBytes} bytes (was ${serialized.length}). Result was serialized to string and middle-truncated. Use \`select\` to return only the fields you need.`;
+    }
+  }
+
+  if (typeof obj.logs === "string" && obj.logs.length > CODEMODE_LOGS_MAX_BYTES) {
+    out.logs = middleTruncate(obj.logs, CODEMODE_LOGS_MAX_BYTES);
+  }
+
+  return out;
+}
+
+export function projectCodemodeResult(result: unknown, paths: string[]): unknown {
+  if (!result || typeof result !== "object") return result;
+  const obj = result as { code?: unknown; result?: unknown; logs?: unknown };
+  if (obj.result === undefined) return result;
+
+  const projected: Record<string, unknown> = {};
+  for (const path of paths) {
+    const value = getByPath(obj.result, path);
+    if (value !== undefined) projected[path] = value;
+  }
+
+  return {
+    ...obj,
+    result: projected,
+    _projected_paths: paths,
+  };
+}
+
+function getByPath(value: unknown, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = value;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    if (Array.isArray(current)) {
+      const idx = Number(part);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= current.length) return undefined;
+      current = current[idx];
+      continue;
+    }
+    if (typeof current === "object") {
+      current = (current as Record<string, unknown>)[part];
+      continue;
+    }
+    return undefined;
+  }
+  return current;
+}
+
+function capText(text: string, maxLines: number, maxBytes: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines && text.length <= maxBytes) return text;
+
+  const kept: string[] = [];
+  let bytes = 0;
+  for (let i = 0; i < lines.length && i < maxLines; i++) {
+    const line = lines[i];
+    if (bytes + line.length + 1 > maxBytes) break;
+    kept.push(line);
+    bytes += line.length + 1;
+  }
+  return kept.join("\n");
+}
+
+// ─── Subagent message-history pruning ───
+
+const SUBAGENT_MSG_WINDOW = 4;
+
+function makePruneMarker(droppedCount: number): ModelMessage {
+  return {
+    role: "user",
+    content: `[system: ${droppedCount} earlier assistant/tool messages were pruned to keep your input token count bounded. If you need information from those steps, call the relevant tool again — don't try to reconstruct the content.]`,
+  };
+}
+
+export function pruneSubagentHistory(
+  messages: Array<ModelMessage>,
+  windowSize: number = SUBAGENT_MSG_WINDOW,
+): Array<ModelMessage> {
+  if (messages.length <= windowSize + 1) return messages;
+
+  const firstUserIdx = messages.findIndex((m) => m.role === "user");
+  if (firstUserIdx < 0) return messages;
+
+  const groups: Array<{ start: number; end: number }> = [];
+  let cursor = messages.length;
+  while (cursor > firstUserIdx + 1 && groups.length < windowSize) {
+    const end = cursor;
+    let start = cursor - 1;
+    while (start > firstUserIdx + 1 && messages[start].role !== "assistant") {
+      start--;
+    }
+    groups.unshift({ start, end });
+    cursor = start;
+  }
+
+  if (groups.length === 0) return messages;
+
+  const head = messages.slice(0, firstUserIdx + 1);
+  const tailStart = groups[0].start;
+  const dropped = tailStart - (firstUserIdx + 1);
+  if (dropped <= 0) return messages;
+  const tail = messages.slice(tailStart);
+  return [...head, makePruneMarker(dropped), ...tail];
+}
+
+export function subagentPrepareStep(options?: { windowSize?: number }) {
+  const windowSize = options?.windowSize ?? SUBAGENT_MSG_WINDOW;
+  return ({ messages }: { messages: Array<ModelMessage> }) => {
+    const pruned = pruneSubagentHistory(messages, windowSize);
+    return pruned === messages ? {} : { messages: pruned };
+  };
+}
+
+// ─── Anthropic prompt caching ───
+
+export function addAnthropicCacheMarkers(body: Record<string, unknown>): Record<string, unknown> {
+  const modelId = typeof body.model === "string" ? body.model : "";
+  if (!modelId.startsWith("anthropic/") && !modelId.startsWith("claude-")) {
+    return body;
+  }
+
+  const out: Record<string, unknown> = { ...body };
+
+  if (typeof out.system === "string" && out.system.length > 0) {
+    out.system = [
+      { type: "text", text: out.system, cache_control: { type: "ephemeral" } },
+    ];
+  } else if (Array.isArray(out.system) && out.system.length > 0) {
+    const hasMarker = out.system.some(
+      (block) => block && typeof block === "object" && "cache_control" in (block as object),
+    );
+    if (!hasMarker) {
+      const last = out.system[out.system.length - 1];
+      if (last && typeof last === "object") {
+        out.system = [
+          ...out.system.slice(0, -1),
+          { ...(last as object), cache_control: { type: "ephemeral" } },
+        ];
+      }
+    }
+  }
+
+  if (Array.isArray(out.tools) && out.tools.length > 0) {
+    const tools = out.tools as unknown[];
+    const hasMarker = tools.some(
+      (t) => t && typeof t === "object" && "cache_control" in (t as object),
+    );
+    if (!hasMarker) {
+      const lastIdx = tools.length - 1;
+      const last = tools[lastIdx];
+      if (last && typeof last === "object") {
+        out.tools = [
+          ...tools.slice(0, lastIdx),
+          { ...(last as object), cache_control: { type: "ephemeral" } },
+        ];
+      }
+    }
+  }
+
+  if (Array.isArray(out.messages) && out.messages.length > 0) {
+    const messages = out.messages as Array<Record<string, unknown>>;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg?.role !== "user") continue;
+      if (typeof msg.content === "string" && msg.content.length > 0) {
+        const updated: Record<string, unknown> = {
+          ...msg,
+          content: [
+            {
+              type: "text",
+              text: msg.content,
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        };
+        out.messages = [...messages.slice(0, i), updated, ...messages.slice(i + 1)];
+      }
+      break;
+    }
+  }
+
+  return out;
+}
+
+// ─── Gateway / provider helpers ───
+
+function trimBaseUrl(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+export function resolveWireModelId(modelId: string, activeGateway: "opencode" | "ai-gateway"): string {
+  if (modelId.startsWith("@cf/")) {
+    if (activeGateway !== "ai-gateway") {
+      throw new Error(
+        `Workers AI model "${modelId}" requires the AI Gateway. ` +
+        `Switch gateway to "ai-gateway" in Settings (or via update_config).`,
+      );
+    }
+    return `workers-ai/${modelId}`;
+  }
+  return modelId;
+}
+
+function resolveGatewayForModel(
+  modelId: string,
+  mainGateway: "opencode" | "ai-gateway",
+): "opencode" | "ai-gateway" {
+  if (modelId.startsWith("@cf/")) return "ai-gateway";
+  return mainGateway;
+}
+
+export function buildProviderForModel(modelId: string, config: AppConfig, env: Env) {
+  const effectiveGateway = resolveGatewayForModel(modelId, config.activeGateway);
+  const isOpencode = effectiveGateway === "opencode";
+  const baseURL = isOpencode
+    ? `${trimBaseUrl(config.opencodeBaseURL)}`
+    : `${trimBaseUrl(config.aiGatewayBaseURL)}`;
+
+  const headers: Record<string, string> = isOpencode
+    ? { "cf-access-token": env.OPENCODE_GATEWAY_TOKEN ?? "" }
+    : {
+        "cf-aig-authorization": `Bearer ${env.AI_GATEWAY_KEY ?? ""}`,
+        "x-api-key": env.AI_GATEWAY_KEY ?? "",
+      };
+
+  const provider = createOpenAICompatible({
+    baseURL,
+    headers,
+    includeUsage: true,
+    name: effectiveGateway,
+    transformRequestBody: addAnthropicCacheMarkers,
+  });
+
+  const translate = (m: string) => resolveWireModelId(m, effectiveGateway);
+  const originalChatModel = provider.chatModel.bind(provider);
+  const originalLanguageModel = provider.languageModel.bind(provider);
+
+  return new Proxy(provider, {
+    apply(_target, _thisArg, args: [string, ...unknown[]]) {
+      const [modelId, ...rest] = args;
+      return originalLanguageModel(translate(modelId), ...(rest as []));
+    },
+    get(target, prop, receiver) {
+      if (prop === "chatModel") return (modelId: string) => originalChatModel(translate(modelId));
+      if (prop === "languageModel") return (modelId: string, cfg?: unknown) => originalLanguageModel(translate(modelId), cfg as Parameters<typeof originalLanguageModel>[1]);
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+// ─── Subagent constants ───
+
+export const EXPLORE_MAX_STEPS = 16;
+export const EXPLORE_TIMEOUT_MS = 60_000;
+
+export const EXPLORE_SYSTEM_PROMPT = [
+  "You are a search assistant. Your job is to find files and code relevant to the user's query.",
+  "",
+  "## Rules",
+  "- Use grep, find, list, and read to search the workspace.",
+  "- Be thorough: try multiple search terms if the first doesn't find results.",
+  `- You have a hard budget of ${EXPLORE_MAX_STEPS} steps. **Reserve the last 2 steps for your summary** — at step ${EXPLORE_MAX_STEPS - 2} or earlier, stop calling tools and write your findings.`,
+  "- Return a concise summary when done: file paths, relevant line numbers, and key observations.",
+  "- Do NOT return full file contents — only the relevant snippets (max 10 lines per file).",
+  "- If you find too many results, narrow your search with more specific patterns.",
+  "- Focus on answering the user's specific question, not cataloguing everything.",
+  "- Emitting SOME summary beats hitting the step limit silent. A rough summary is recoverable; no summary wastes the caller's retry budget.",
+].join("\n");
+
+const EXPLORE_MODELS: Record<string, string> = {
+  "anthropic/": "anthropic/claude-haiku-4-5",
+  "openai/": "openai/gpt-4.1-mini",
+  "google/": "google/gemini-2.5-flash",
+  "deepseek/": "deepseek/deepseek-chat",
+};
+
+function getExploreModel(mainModel: string): string {
+  for (const [prefix, model] of Object.entries(EXPLORE_MODELS)) {
+    if (mainModel.startsWith(prefix)) return model;
+  }
+  return mainModel;
+}
+
+export const TASK_MAX_STEPS = 20;
+export const TASK_TIMEOUT_MS = 180_000;
+export const TASK_FACET_TIMEOUT_MS = 600_000;
+
+export const TASK_SYSTEM_PROMPT = [
+  "You are a focused subagent dispatched by the main Dodo agent to handle one bounded task.",
+  "",
+  "## Rules",
+  "- You have a subset of the main agent's tools. Use them to complete the task and ONLY the task.",
+  "- Do not ask clarifying questions — make a best-effort attempt with the info given.",
+  `- You have a hard budget of ${TASK_MAX_STEPS} steps. **Reserve the last 2 steps for your summary** — at step ${TASK_MAX_STEPS - 2} or earlier, stop calling tools and write your summary.`,
+  "- Return a compact text summary when done. Include: what you did, paths/line numbers touched, test results if any.",
+  "- Do NOT dump large tool outputs into your final message — summarize in 5-15 lines.",
+  "- If you hit your step budget without finishing, report what was done and what remains. Your caller will retry.",
+  "- Emitting SOME summary beats hitting the step limit silent. A rough summary is recoverable; no summary wastes the caller's retry budget.",
+].join("\n");
+
+export function resolveSubagentModel(
+  args: Record<string, unknown>,
+  sessionDefault: string | undefined,
+  mainModel: string,
+): string {
+  const rawArgModel = args.model;
+  if (typeof rawArgModel === "string" && rawArgModel.trim().length > 0) {
+    return rawArgModel.trim();
+  }
+  if (typeof sessionDefault === "string" && sessionDefault.trim().length > 0) {
+    return sessionDefault.trim();
+  }
+  return getExploreModel(mainModel);
+}
+
+// ─── Subagent runner ───
+
+export interface SubagentInvocation {
+  kind: "explore" | "task";
+  prompt: string;
+  model: string;
+  config: AppConfig;
+  toolset: ToolSet;
+  systemPrompt: string;
+  maxSteps: number;
+  timeoutMs?: number;
+  prepareStep?: ({ messages }: { messages: Array<ModelMessage> }) => { messages?: Array<ModelMessage> };
+  env: Env;
+  signal?: AbortSignal;
+}
+
+export interface SubagentResult {
+  finalText: string;
+  steps: number;
+  toolCalls: string[];
+  stoppedReason: "max-steps" | "tool-call-final" | "abort" | "timeout";
+  transcript: Array<{ role: string; content: string }>;
+  tokenInput: number;
+  tokenOutput: number;
+}
+
+export async function runSubagent(input: SubagentInvocation): Promise<SubagentResult> {
+  const provider = buildProviderForModel(input.model, input.config, input.env);
+  const model = provider.chatModel(input.model);
+
+  const messages = [{ role: "user" as const, content: input.prompt }];
+
+  try {
+    const result = await generateText({
+      model,
+      system: input.systemPrompt,
+      messages,
+      tools: input.toolset,
+      stopWhen: stepCountIs(input.maxSteps),
+      maxOutputTokens: 4000,
+      prepareStep: input.prepareStep ?? subagentPrepareStep(),
+      abortSignal: input.signal ?? (input.timeoutMs ? AbortSignal.timeout(input.timeoutMs) : undefined),
+    });
+
+    const steps = result.steps.length;
+    const toolCalls = result.steps.flatMap((s) =>
+      (s.toolCalls ?? []).map((tc) => tc.toolName),
+    );
+    const totalInput = result.steps.reduce((sum, s) => sum + (s.usage?.inputTokens ?? 0), 0);
+    const totalOutput = result.steps.reduce((sum, s) => sum + (s.usage?.outputTokens ?? 0), 0);
+    const stoppedReason = steps >= input.maxSteps ? "max-steps" : "tool-call-final";
+
+    const transcript: Array<{ role: string; content: string }> = [
+      { role: "user", content: input.prompt },
+      ...result.steps.flatMap((step) => {
+        const entries: Array<{ role: string; content: string }> = [];
+        if (step.text) {
+          entries.push({ role: "assistant", content: step.text });
+        }
+        for (const tc of step.toolCalls ?? []) {
+          const args = (tc as { args?: unknown }).args;
+          entries.push({ role: "tool", content: `${tc.toolName}: ${JSON.stringify(args)}` });
+        }
+        return entries;
+      }),
+    ];
+
+    return {
+      finalText: result.text,
+      steps,
+      toolCalls,
+      stoppedReason,
+      transcript,
+      tokenInput: totalInput,
+      tokenOutput: totalOutput,
+    };
+  } catch (error) {
+    if (error instanceof DOMException) {
+      if (error.name === "AbortError") {
+        return {
+          finalText: "",
+          steps: 0,
+          toolCalls: [],
+          stoppedReason: "abort",
+          transcript: [{ role: "user", content: input.prompt }],
+          tokenInput: 0,
+          tokenOutput: 0,
+        };
+      }
+      if (error.name === "TimeoutError") {
+        return {
+          finalText: "",
+          steps: 0,
+          toolCalls: [],
+          stoppedReason: "timeout",
+          transcript: [{ role: "user", content: input.prompt }],
+          tokenInput: 0,
+          tokenOutput: 0,
+        };
+      }
+    }
+    throw error;
+  }
+}

--- a/src/task-agent.ts
+++ b/src/task-agent.ts
@@ -1,6 +1,6 @@
 import { Workspace } from "@cloudflare/shell";
 import { Agent, getAgentByName } from "agents";
-import { generateText, stepCountIs, type ToolSet } from "ai";
+import { type ToolSet } from "ai";
 import {
   createReadTool,
   createListTool,
@@ -8,16 +8,14 @@ import {
   createGrepTool,
   createWriteTool,
   createEditTool,
-} from "@cloudflare/think/tools/workspace";
+} from "./think-adapter";
 import {
-  buildProviderForModel,
-  capToolOutputs,
+  runSubagent,
   resolveSubagentModel,
-  subagentPrepareStep,
   TASK_SYSTEM_PROMPT,
   TASK_MAX_STEPS,
   TASK_FACET_TIMEOUT_MS,
-} from "./agentic";
+} from "./subagent-runner";
 import type { AppConfig, Env } from "./types";
 import type { CodingAgent } from "./coding-agent";
 
@@ -221,8 +219,6 @@ export class TaskAgent extends Agent<Env> {
     const workspaceMode: "shared" | "scratch" = opts.workspaceMode ?? "shared";
 
     const modelId = resolveSubagentModel({ model: opts.model }, config.taskModel, config.model);
-    const provider = buildProviderForModel(modelId, config, this.env);
-    const model = provider.chatModel(modelId);
 
     const parent = (await getAgentByName(
       this.env.CODING_AGENT as never,
@@ -264,45 +260,35 @@ export class TaskAgent extends Agent<Env> {
     const timeoutMs = TASK_FACET_TIMEOUT_MS;
 
     try {
-      const result = await generateText({
-        model,
-        system: TASK_SYSTEM_PROMPT,
-        messages: [{ role: "user" as const, content: userMessage }],
-        tools: taskTools,
-        stopWhen: stepCountIs(TASK_MAX_STEPS),
-        maxOutputTokens: 4000,
-        // See `subagentPrepareStep` in agentic.ts — prunes tool-result
-        // accumulation across steps. Task has more tool call variety than
-        // explore (write + edit in addition to read/grep/find) so the
-        // accumulation curve is steeper without this.
-        prepareStep: subagentPrepareStep(),
-        abortSignal: AbortSignal.timeout(timeoutMs),
+      const result = await runSubagent({
+        kind: "task",
+        prompt: userMessage,
+        model: modelId,
+        config,
+        toolset: taskTools,
+        systemPrompt: TASK_SYSTEM_PROMPT,
+        maxSteps: TASK_MAX_STEPS,
+        timeoutMs,
+        env: this.env,
       });
 
-      const summaryText = result.text;
-      const steps = result.steps.length;
-      const toolCalls = result.steps.flatMap((s) =>
-        (s.toolCalls ?? []).map((tc) => tc.toolName),
-      );
-      const totalInput = result.steps.reduce((sum, s) => sum + (s.usage?.inputTokens ?? 0), 0);
-      const totalOutput = result.steps.reduce((sum, s) => sum + (s.usage?.outputTokens ?? 0), 0);
-      const usageLine = totalInput > 0 || totalOutput > 0
-        ? `**Tokens:** ${totalInput} in / ${totalOutput} out | `
+      const usageLine = result.tokenInput > 0 || result.tokenOutput > 0
+        ? `**Tokens:** ${result.tokenInput} in / ${result.tokenOutput} out | `
         : "";
 
       const modeLabel = workspaceMode === "scratch" ? " [scratch workspace]" : "";
       const formatted = [
         `## Task results (model: ${modelId}) [facet: ${this.name}]${modeLabel}`,
-        `${usageLine}**Steps:** ${steps} | **Tools used:** ${toolCalls.join(", ") || "none"}`,
+        `${usageLine}**Steps:** ${result.steps} | **Tools used:** ${result.toolCalls.join(", ") || "none"}`,
         "",
-        summaryText || "(No output — task ran its step budget without emitting a summary.)",
+        result.finalText || "(No output — task ran its step budget without emitting a summary.)",
       ].filter(Boolean).join("\n");
 
       this.recordTranscript("assistant", formatted, {
         model: modelId,
         workspaceMode,
-        tokenInput: totalInput,
-        tokenOutput: totalOutput,
+        tokenInput: result.tokenInput,
+        tokenOutput: result.tokenOutput,
       });
 
       return {
@@ -310,8 +296,8 @@ export class TaskAgent extends Agent<Env> {
         facetName: this.name,
         summary: formatted,
         workspaceMode,
-        tokenInput: totalInput,
-        tokenOutput: totalOutput,
+        tokenInput: result.tokenInput,
+        tokenOutput: result.tokenOutput,
         scratchWrites: workspaceMode === "scratch" ? this.listScratchWrites() : undefined,
       };
     } catch (error) {
@@ -417,7 +403,7 @@ export class TaskAgent extends Agent<Env> {
    * canonical session state.
    */
   private buildSharedTools(parent: ParentStub): ToolSet {
-    return capToolOutputs({
+    return {
       read: createReadTool({
         ops: {
           readFile: (path: string) => parent.facetReadFile(path),
@@ -455,7 +441,7 @@ export class TaskAgent extends Agent<Env> {
           },
         },
       }),
-    });
+    };
   }
 
   /**
@@ -484,7 +470,7 @@ export class TaskAgent extends Agent<Env> {
       this.recordScratchWrite(path);
     };
 
-    return capToolOutputs({
+    return {
       read: createReadTool({
         ops: {
           readFile: readFromScratchThenParent,
@@ -571,7 +557,7 @@ export class TaskAgent extends Agent<Env> {
           writeFile: writeToScratch,
         },
       }),
-    });
+    };
   }
 
   /**

--- a/src/think-adapter.ts
+++ b/src/think-adapter.ts
@@ -17,6 +17,14 @@ export type {
 } from "@cloudflare/think";
 
 export { createWorkspaceTools } from "@cloudflare/think/tools/workspace";
+export {
+  createReadTool,
+  createListTool,
+  createFindTool,
+  createGrepTool,
+  createWriteTool,
+  createEditTool,
+} from "@cloudflare/think/tools/workspace";
 export { createExecuteTool } from "@cloudflare/think/tools/execute";
 export { truncateToolOutput } from "@cloudflare/think/session";
 

--- a/test/anthropic-cache-unit.test.ts
+++ b/test/anthropic-cache-unit.test.ts
@@ -10,7 +10,7 @@
  * compaction, regardless of the session's default model).
  */
 import { describe, expect, it } from "vitest";
-import { addAnthropicCacheMarkers } from "../src/agentic";
+import { addAnthropicCacheMarkers } from "../src/subagent-runner";
 
 const ANTHROPIC_MODEL = "anthropic/claude-opus-4-7";
 

--- a/test/facet-explore-parallel-unit.test.ts
+++ b/test/facet-explore-parallel-unit.test.ts
@@ -27,6 +27,7 @@ vi.mock("@cloudflare/codemode", async (importOriginal) => {
   };
 });
 vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/subagent-runner", async () => await import("./helpers/subagent-runner-mock"));
 vi.mock("../src/notify", () => ({
   sendNotification: vi.fn(),
 }));

--- a/test/facet-explore-unit.test.ts
+++ b/test/facet-explore-unit.test.ts
@@ -27,6 +27,7 @@ vi.mock("@cloudflare/codemode", async (importOriginal) => {
   };
 });
 vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/subagent-runner", async () => await import("./helpers/subagent-runner-mock"));
 vi.mock("../src/notify", () => ({
   sendNotification: vi.fn(),
 }));

--- a/test/facet-scaffold-unit.test.ts
+++ b/test/facet-scaffold-unit.test.ts
@@ -31,6 +31,7 @@ vi.mock("@cloudflare/codemode", async (importOriginal) => {
   };
 });
 vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/subagent-runner", async () => await import("./helpers/subagent-runner-mock"));
 vi.mock("../src/notify", () => ({
   sendNotification: vi.fn(),
 }));

--- a/test/facet-task-scratch-unit.test.ts
+++ b/test/facet-task-scratch-unit.test.ts
@@ -30,6 +30,7 @@ vi.mock("@cloudflare/codemode", async (importOriginal) => {
   };
 });
 vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/subagent-runner", async () => await import("./helpers/subagent-runner-mock"));
 vi.mock("../src/notify", () => ({
   sendNotification: vi.fn(),
 }));

--- a/test/facet-transcript-unit.test.ts
+++ b/test/facet-transcript-unit.test.ts
@@ -28,6 +28,7 @@ vi.mock("@cloudflare/codemode", async (importOriginal) => {
   };
 });
 vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/subagent-runner", async () => await import("./helpers/subagent-runner-mock"));
 vi.mock("../src/notify", () => ({
   sendNotification: vi.fn(),
 }));

--- a/test/helpers/subagent-runner-mock.ts
+++ b/test/helpers/subagent-runner-mock.ts
@@ -1,0 +1,137 @@
+import { vi } from "vitest";
+
+// Re-export constants verbatim so facet tests see the same budgets.
+export const EXPLORE_MAX_STEPS = 16;
+export const EXPLORE_TIMEOUT_MS = 60_000;
+export const TASK_MAX_STEPS = 20;
+export const TASK_TIMEOUT_MS = 180_000;
+export const TASK_FACET_TIMEOUT_MS = 600_000;
+
+export const EXPLORE_SYSTEM_PROMPT = "You are a search assistant (mock).";
+export const TASK_SYSTEM_PROMPT = "You are a focused subagent (mock).";
+
+// Pass-through helpers — real behaviour is fine for tests since they
+// touch no I/O.
+export function capToolOutputs<T extends Record<string, unknown>>(tools: T): T {
+  return tools;
+}
+
+export function subagentPrepareStep(_options?: { windowSize?: number }) {
+  return () => ({});
+}
+
+export function pruneSubagentHistory<T extends Array<unknown>>(messages: T): T {
+  return messages;
+}
+
+function getExploreModel(mainModel: string): string {
+  if (mainModel.startsWith("anthropic/")) return "anthropic/claude-haiku-4-5";
+  if (mainModel.startsWith("openai/")) return "openai/gpt-4.1-mini";
+  return mainModel;
+}
+
+export function resolveSubagentModel(
+  args: Record<string, unknown>,
+  sessionDefault: string | undefined,
+  mainModel: string,
+): string {
+  const rawArgModel = args.model;
+  if (typeof rawArgModel === "string" && rawArgModel.trim().length > 0) {
+    return rawArgModel.trim();
+  }
+  if (typeof sessionDefault === "string" && sessionDefault.trim().length > 0) {
+    return sessionDefault.trim();
+  }
+  return getExploreModel(mainModel);
+}
+
+export const buildProviderForModel = vi.fn().mockImplementation((modelId: string, config: { activeGateway?: string }) => ({
+  chatModel: (id: string) => ({
+    specificationVersion: "v2" as const,
+    provider: "mock-provider",
+    modelId: id,
+    supportedUrls: {},
+    doGenerate: async (options: { prompt: unknown }) => {
+      const prompt = extractUserText(options.prompt);
+      if (shouldFail(prompt)) {
+        throw new Error("Gateway timeout");
+      }
+      return {
+        content: [{ type: "text", text: makeText(config.activeGateway ?? "opencode", prompt) }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      };
+    },
+    doStream: async (options: { prompt: unknown }) => {
+      const prompt = extractUserText(options.prompt);
+      return {
+        stream: makeStream(makeText(config.activeGateway ?? "opencode", prompt)),
+      };
+    },
+  }),
+  chat: () => ({}),
+  completion: () => ({}),
+  textEmbedding: () => ({}),
+  image: () => ({}),
+  languageModel: () => ({}),
+  [Symbol.toPrimitive]: () => "mock-provider",
+}));
+
+export const runSubagent = vi.fn().mockImplementation(async (input: {
+  kind: "explore" | "task";
+  prompt: string;
+  model: string;
+}) => {
+  return {
+    finalText: `${input.model}:${input.prompt}`,
+    steps: 1,
+    toolCalls: [],
+    stoppedReason: "tool-call-final",
+    transcript: [
+      { role: "user", content: input.prompt },
+      { role: "assistant", content: `${input.model}:${input.prompt}` },
+    ],
+    tokenInput: 1,
+    tokenOutput: 1,
+  };
+});
+
+// ─── Internal helpers copied from agentic-mock ───
+
+type PromptPart = { type?: string; text?: string };
+type PromptMessage = { role?: string; content?: unknown };
+
+function extractUserText(prompt: unknown): string {
+  if (!Array.isArray(prompt)) return "";
+  const messages = prompt as PromptMessage[];
+  const lastUser = [...messages].reverse().find((msg) => msg.role === "user");
+  if (!lastUser) return "";
+  if (!Array.isArray(lastUser.content)) return "";
+  return (lastUser.content as PromptPart[])
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text ?? "")
+    .join(" ")
+    .trim();
+}
+
+function makeText(gateway: string, prompt: string): string {
+  return `${gateway}:${prompt}`;
+}
+
+function shouldFail(prompt: string): boolean {
+  return prompt.includes("This should fail") || prompt.includes("This will fail");
+}
+
+function makeStream(text: string): ReadableStream<unknown> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: "stream-start", warnings: [] });
+      controller.enqueue({ type: "text-start", id: "t1" });
+      controller.enqueue({ type: "text-delta", id: "t1", delta: text });
+      controller.enqueue({ type: "text-end", id: "t1" });
+      controller.enqueue({ type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } });
+      controller.close();
+    },
+  });
+}

--- a/test/model-routing-unit.test.ts
+++ b/test/model-routing-unit.test.ts
@@ -13,7 +13,7 @@
  * Keep this file in sync with the canonical versions in src/.
  */
 import { describe, expect, it } from "vitest";
-import { resolveWireModelId } from "../src/agentic";
+import { resolveWireModelId } from "../src/subagent-runner";
 
 // ─── Mirror of isRoutableByOpencodeGateway from src/shared-index.ts ───
 

--- a/test/subagent-model-unit.test.ts
+++ b/test/subagent-model-unit.test.ts
@@ -6,7 +6,7 @@
  * spinning up a provider / real LLM.
  */
 import { describe, expect, it } from "vitest";
-import { resolveSubagentModel } from "../src/agentic";
+import { resolveSubagentModel } from "../src/subagent-runner";
 
 const MAIN_ANTHROPIC = "anthropic/claude-opus-4-7";
 const MAIN_OPENAI = "openai/gpt-5.4";

--- a/test/subagent-prune-unit.test.ts
+++ b/test/subagent-prune-unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ModelMessage } from "ai";
-import { pruneSubagentHistory, subagentPrepareStep } from "../src/agentic";
+import { pruneSubagentHistory, subagentPrepareStep } from "../src/subagent-runner";
 
 /**
  * `pruneSubagentHistory` is the inter-step message-compaction used by the


### PR DESCRIPTION
## Summary
- New \`src/subagent-runner.ts\` is the single implementation of the explore/task subagent loop
- Both entry points — \`buildExploreTool\`/\`buildTaskTool\` in \`agentic.ts\` and \`ExploreAgent.query\`/\`TaskAgent.task\` in their DO files — now call \`runSubagent(...)\`
- Constants (\`EXPLORE_MAX_STEPS\`, \`TASK_TIMEOUT_MS\`, system prompts) and helpers (\`capToolOutputs\`, \`subagentPrepareStep\`, \`resolveSubagentModel\`, \`buildProviderForModel\`) move out of \`agentic.ts\` into \`subagent-runner.ts\`
- \`agentic.ts\` public surface shrinks to \`buildProvider\` + \`buildToolsForThink\`
- \`think-adapter.ts\` extended to re-export individual workspace tool factories — fixes the AGENTS.md invariant violation in \`explore-agent.ts\` and \`task-agent.ts\`

## Why
Two parallel implementations of the same loop drifted on timeouts. Future changes to subagent behaviour now apply once. Per the \`improve-codebase-architecture\` audit, candidate #1.

## Divergences resolved
- **Prompts:** \`EXPLORE_SYSTEM_PROMPT\` and \`TASK_SYSTEM_PROMPT\` were already identical between both paths
- **Step caps:** identical (EXPLORE_MAX_STEPS=16, TASK_MAX_STEPS=20)
- **Timeouts:** in-process explore=60s, facet explore=60s (same); in-process task=180s, facet task=600s (intentionally longer for facet). \`runSubagent\` preserves both via configurable \`timeoutMs\`
- **Tool subset:** unchanged (read/list/find/grep for explore; +write/edit for task)

## Test plan
- \`npm run typecheck\` — clean
- \`npm test\` — clean (57 files / 656 tests, including 5 facet test files)
- \`npm run lint\` — clean