### PR TITLE
refactor(coding-agent): extract pure decision functions

### DIFF
--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -50,11 +50,14 @@ import {
 import type { AppConfig, ChatMessageRecord, CronJobRecord, Env, PromptRecord, SessionEvent, SessionSnapshot, SessionState, TodoItem, TodoPriority, TodoStatus, TodoStore, WorkspaceEntry } from "./types";
 import {
   DEFAULT_NUDGE_PROMPT,
-  decideWatchdog,
   formatStallBody,
   normaliseWatchdogConfig,
   type WatchdogConfig,
 } from "./watchdog";
+import { shouldCompact, pickCutoff } from "./compaction-policy";
+import { nextRetry } from "./overflow-retry";
+import { assembleSystemPrompt } from "./prompt-composer";
+import { evaluateSession } from "./watchdog-policy";
 
 /**
  * Context window sizes (in tokens) by model ID. Used for token budget enforcement.
@@ -507,76 +510,50 @@ export class CodingAgent extends Think<Env, DodoConfig> {
   }
 
   override getSystemPrompt(): string {
-    let prompt = SYSTEM_PROMPT;
-
-    // Skill manifest — name + description per available skill. Bodies are
-    // not included; the model loads them on demand via the `skill` tool.
-    // Warmed by `warmSkills()` in onChatMessage before this call.
-    if (this._skillManifest) {
-      prompt = `${prompt}\n\n${this._skillManifest}`;
-    }
-
-    // Conditionally include browser tools section
+    // Gather the optional sections that depend on DO state.
     const browserEnabled = this.readMetadata("browser_enabled") === "true";
-    if (browserEnabled) {
-      prompt += [
-        "",
-        "",
-        "## Browser",
-        "",
-        "You have full browser automation via the Chrome DevTools Protocol (CDP).",
-        "",
-        "**Two tools:**",
-        "- `browser_search` — Write JS to query the CDP spec (~1.7MB, stays server-side). Use this to discover available commands, events, and types before executing them.",
-        "- `browser_execute` — Write JS using a `cdp` helper to run CDP commands against a live headless Chrome session. The session is opened fresh per call and closed after.",
-        "",
-        "**`browser_execute` pattern:**",
-        "A fresh browser with a blank page is launched per call. The CDP session is already attached to that page,",
-        "so you can send page-scoped commands directly:",
-        "1. Enable domains: `cdp.send(\"Page.enable\")`",
-        "2. Navigate: `cdp.send(\"Page.navigate\", { url: \"...\" })`",
-        "3. Wait for load, then act: `cdp.send(\"Page.captureScreenshot\", { format: \"png\" })`",
-        "",
-        "**Common tasks:**",
-        "- Navigate + get text: `Page.navigate` → `Runtime.evaluate` with `document.body.innerText`",
-        "- Screenshot: `Page.captureScreenshot` → returns base64 PNG",
-        "- Click/type: `Input.dispatchMouseEvent`, `Input.dispatchKeyEvent`",
-        "- Network: `Network.enable` → intercept/monitor requests",
-        "- DOM inspection: `DOM.getDocument` → `DOM.querySelectorAll`",
-        "",
-        "Always use `browser_search` first if you're unsure which CDP method to use.",
-      ].join("\n");
-    }
+    const browserSection = browserEnabled
+      ? [
+          "## Browser",
+          "",
+          "You have full browser automation via the Chrome DevTools Protocol (CDP).",
+          "",
+          "**Two tools:**",
+          "- `browser_search` — Write JS to query the CDP spec (~1.7MB, stays server-side). Use this to discover available commands, events, and types before executing them.",
+          "- `browser_execute` — Write JS using a `cdp` helper to run CDP commands against a live headless Chrome session. The session is opened fresh per call and closed after.",
+          "",
+          "**`browser_execute` pattern:**",
+          "A fresh browser with a blank page is launched per call. The CDP session is already attached to that page,",
+          "so you can send page-scoped commands directly:",
+          '1. Enable domains: `cdp.send("Page.enable")`',
+          '2. Navigate: `cdp.send("Page.navigate", { url: "..." })`',
+          '3. Wait for load, then act: `cdp.send("Page.captureScreenshot", { format: "png" })`',
+          "",
+          "**Common tasks:**",
+          '- Navigate + get text: `Page.navigate` → `Runtime.evaluate` with `document.body.innerText`',
+          '- Screenshot: `Page.captureScreenshot` → returns base64 PNG',
+          '- Click/type: `Input.dispatchMouseEvent`, `Input.dispatchKeyEvent`',
+          '- Network: `Network.enable` → intercept/monitor requests',
+          '- DOM inspection: `DOM.getDocument` → `DOM.querySelectorAll`',
+          "",
+          "Always use `browser_search` first if you're unsure which CDP method to use.",
+        ].join("\n")
+      : undefined;
 
     // Inject bounded workspace summary on first turn only.
-    // Use this.messages.length <= 1 because Think's chat() persists the
-    // user message before calling onChatMessage() → getSystemPrompt(),
-    // so messageCount() is already 1 on the first turn.
-    if (this.messages.length <= 1) {
-      const summary = this.getWorkspaceSummary();
-      if (summary) {
-        prompt = `${prompt}\n\n## Current workspace\n\n${summary}`;
-      }
-    }
+    const workspaceSummary =
+      this.messages.length <= 1 ? this.getWorkspaceSummary() ?? undefined : undefined;
 
-    // Inject project instructions (AGENTS.md / CLAUDE.md) if loaded.
-    // Warmed by `warmProjectInstructions()` in onChatMessage before this
-    // call, so it's safe to read synchronously. Included on every turn so
-    // compaction summaries don't lose project-specific rules.
-    if (this._projectInstructions) {
-      prompt = `${prompt}\n\n## Project instructions\n\n${this._projectInstructions}`;
-    }
-
-    // Prepend user-customisable prefix (systemPromptPrefix in DodoConfig).
-    // Placed at the very top so user rules take precedence over the default
-    // Dodo prompt when models resolve conflicts.
     const config = this.getConfig();
-    const prefix = config?.systemPromptPrefix?.trim();
-    if (prefix) {
-      prompt = `${prefix}\n\n---\n\n${prompt}`;
-    }
 
-    return prompt;
+    return assembleSystemPrompt({
+      staticBase: SYSTEM_PROMPT,
+      skillManifest: this._skillManifest ?? undefined,
+      browserSection,
+      workspaceSummary,
+      projectInstructions: this._projectInstructions ?? undefined,
+      userPrefix: config?.systemPromptPrefix?.trim(),
+    });
   }
 
   /**
@@ -1204,11 +1181,13 @@ export class CodingAgent extends Think<Env, DodoConfig> {
             // Detect context overflow errors and trigger emergency compaction.
             // Only attempt once per onChatMessage() invocation to prevent infinite loops.
             const errMsg = err instanceof Error ? err.message : String(err);
-            const isOverflow = /context.*(length|limit|overflow|window|too long|exceed)/i.test(errMsg)
-              || /max.*token/i.test(errMsg)
-              || /request too large/i.test(errMsg);
+            const decision = nextRetry({
+              previousAttempts: self._overflowRecoveryAttempted ? 1 : 0,
+              maxAttempts: 1,
+              error: { message: errMsg },
+            });
 
-            if (isOverflow && !self._overflowRecoveryAttempted) {
+            if (decision.kind === "retry-with-truncation") {
               self._overflowRecoveryAttempted = true;
               log("warn", "own-loop: context overflow detected, attempting emergency compaction", {
                 sessionId,
@@ -1931,13 +1910,6 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const contextWindow = CONTEXT_WINDOW_TOKENS[modelId] ?? DEFAULT_CONTEXT_WINDOW;
     const tokenBudget = Math.floor(contextWindow * CONTEXT_BUDGET_FACTOR);
 
-    // Use the top-of-file estimateMessageTokens which is content-aware
-    // (separate chars-per-token ratios for prose / code / JSON / default).
-    // Prior versions had a shadow `estimateTokens` here using a flat 3.5
-    // ratio — that under-counted code/JSON by 15-25% and let oversized
-    // messages slip past the cutoff walk below.
-    const estimateTokens = estimateMessageTokens;
-
     // ─── Protect compaction summaries from being dropped ───
     // The compaction summary (injected above or by Think's getHistory) MUST survive
     // token-budget enforcement — it's the compressed representation of older messages.
@@ -1950,75 +1922,45 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     // Set the floor to the index AFTER the compaction summary so it's always included.
     const cutoffFloor = minProtectedIndex >= 0 ? minProtectedIndex : 0;
 
+    // Build CutoffMessage array with pre-computed token estimates.
+    const cutoffMessages = messages.map((msg) => ({
+      role: msg.role,
+      tokens: estimateMessageTokens(msg),
+      pinned:
+        msg.role === "system" &&
+        (typeof msg.content === "string" ? msg.content : "").startsWith(COMPACTION_MARKER),
+    }));
+
+    const anchorTokens = this._lastUsage?.inputTokens ?? 0;
+    const cutoffResult = pickCutoff({
+      messages: cutoffMessages,
+      targetTokenBudget: tokenBudget,
+      anchorTokens: anchorTokens > 0 ? anchorTokens : undefined,
+      cutoffFloor,
+    });
+
+    const totalTokens = cutoffMessages
+      .slice(cutoffResult.cutoffIndex)
+      .reduce((sum, m) => sum + m.tokens, 0);
+
     // Log compaction detection for debugging
-    if (messages.some(m => m.role === "system")) {
+    if (messages.some((m) => m.role === "system")) {
       log("info", "assembleContext: system messages found", {
         sessionId: this.sessionId(),
         totalMessages: messages.length,
-        systemCount: messages.filter(m => m.role === "system").length,
+        systemCount: messages.filter((m) => m.role === "system").length,
         minProtectedIndex,
         systemPreviews: messages
-          .map((m, i) => m.role === "system" ? { i, preview: (typeof m.content === "string" ? m.content : JSON.stringify(m.content)).slice(0, 80) } : null)
+          .map((m, i) =>
+            m.role === "system"
+              ? {
+                  i,
+                  preview: (typeof m.content === "string" ? m.content : JSON.stringify(m.content)).slice(0, 80),
+                }
+              : null,
+          )
           .filter(Boolean),
       });
-    }
-
-
-
-    // Hybrid approach: use provider-reported tokens as anchor if available.
-    // _lastUsage.inputTokens is the cumulative input tokens from the current
-    // onChatMessage() run. If available, it's a near-exact count for everything
-    // except the trailing messages added after the last LLM call.
-    const anchorTokens = this._lastUsage?.inputTokens ?? 0;
-    let totalTokens = 0;
-    let cutoffIndex = 0;
-
-    if (anchorTokens > 0 && messages.length > 0) {
-      // Find the last assistant message (the anchor point)
-      let anchorIndex = -1;
-      for (let i = messages.length - 1; i >= 0; i--) {
-        if (messages[i].role === "assistant") { anchorIndex = i; break; }
-      }
-      if (anchorIndex >= 0) {
-        // Estimate only trailing messages after the anchor
-        let trailingTokens = 0;
-        for (let i = anchorIndex + 1; i < messages.length; i++) {
-          trailingTokens += estimateTokens(messages[i]);
-        }
-        totalTokens = anchorTokens + trailingTokens;
-        // Walk backwards from the anchor to find cutoff if budget exceeded
-        if (totalTokens > tokenBudget) {
-          let budget = tokenBudget - trailingTokens;
-          for (let i = anchorIndex; i >= 0; i--) {
-            const msgTokens = estimateTokens(messages[i]);
-            if (budget - msgTokens < 0) {
-              cutoffIndex = Math.max(i + 1, cutoffFloor);
-              break;
-            }
-            budget -= msgTokens;
-          }
-        }
-      } else {
-        // No assistant message yet — fall back to pure estimation
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const msgTokens = estimateTokens(messages[i]);
-          if (totalTokens + msgTokens > tokenBudget) {
-            cutoffIndex = Math.max(i + 1, cutoffFloor);
-            break;
-          }
-          totalTokens += msgTokens;
-        }
-      }
-    } else {
-      // No provider-reported usage yet — pure estimation (first turn)
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const msgTokens = estimateTokens(messages[i]);
-        if (totalTokens + msgTokens > tokenBudget) {
-          cutoffIndex = Math.max(i + 1, cutoffFloor);
-          break;
-        }
-        totalTokens += msgTokens;
-      }
     }
 
     // ─── Current-turn overshoot check (Phase 1.4) ───
@@ -2026,7 +1968,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     // This catches the case where many tool calls in a single turn accumulate.
     if (messages.length > 0) {
       const lastMsg = messages[messages.length - 1];
-      const lastMsgTokens = estimateTokens(lastMsg);
+      const lastMsgTokens = estimateMessageTokens(lastMsg);
       if (lastMsgTokens > tokenBudget * 0.5) {
         log("warn", "assembleContext: single message uses >50% of token budget", {
           sessionId: this.sessionId(),
@@ -2050,13 +1992,13 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       estimatedTokens: totalTokens,
       tokenBudget,
       contextWindow,
-      dropped: cutoffIndex > 0 ? cutoffIndex : 0,
+      dropped: cutoffResult.cutoffIndex,
     });
 
-    if (cutoffIndex > 0 && cutoffIndex < messages.length) {
+    if (cutoffResult.cutoffIndex > 0 && cutoffResult.cutoffIndex < messages.length) {
       this._contextTruncated = true;
-      const droppedCount = cutoffIndex;
-      const hasCompactionSummary = minProtectedIndex >= 0 && minProtectedIndex < cutoffIndex;
+      const droppedCount = cutoffResult.cutoffIndex;
+      const hasCompactionSummary = minProtectedIndex >= 0 && minProtectedIndex < cutoffResult.cutoffIndex;
       log("warn", "assembleContext: dropping oldest messages", {
         sessionId: this.sessionId(),
         droppedCount,
@@ -2078,7 +2020,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
         content: `[Earlier messages truncated — context window limit reached. ${droppedCount} message(s) dropped to stay within the ${contextWindow}-token context window.]`,
       };
 
-      return [...preserved, truncationNote, ...messages.slice(cutoffIndex)];
+      return [...preserved, truncationNote, ...messages.slice(cutoffResult.cutoffIndex)];
     }
 
     return messages;
@@ -3585,14 +3527,17 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const updatedIso = this.readMetadata("updated_at");
     const updatedAtEpoch = updatedIso ? Math.floor(Date.parse(updatedIso) / 1000) : null;
 
-    const decision = decideWatchdog(config, {
-      nowEpoch: now,
-      status: this.readMetadata("status"),
-      activePromptId: this.readMetadata("active_prompt_id"),
-      updatedAtEpoch: Number.isFinite(updatedAtEpoch) ? updatedAtEpoch : null,
-      lastFiredForPromptId: this.readMetadata("watchdog_last_fired_for_prompt_id") || null,
-    });
-    if (!decision) return;
+    const verdict = evaluateSession(
+      {
+        status: this.readMetadata("status"),
+        activePromptId: this.readMetadata("active_prompt_id"),
+        lastActivityAt: updatedAtEpoch ?? 0,
+        lastFiredForPromptId: this.readMetadata("watchdog_last_fired_for_prompt_id") || null,
+        config,
+      },
+      now * 1000,
+    );
+    if (verdict.kind !== "stalled") return;
 
     const sessionId = this.readMetadata("session_id") ?? "unknown";
     const title = this.readMetadata("title") ?? sessionId;
@@ -3601,15 +3546,15 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     // Record fire BEFORE taking action so a retry of this same tick
     // (alarm replay) won't double-fire.
     this.writeMetadata("watchdog_last_fired_at", String(now));
-    this.writeMetadata("watchdog_last_fired_for_prompt_id", decision.activePromptId);
+    this.writeMetadata("watchdog_last_fired_for_prompt_id", verdict.activePromptId);
     this.writeMetadata(
       "watchdog_fire_count",
       String(Number(this.readMetadata("watchdog_fire_count") ?? "0") + 1),
     );
 
-    const body = formatStallBody(sessionId, decision, config.action);
+    const body = formatStallBody(sessionId, verdict, config.action);
 
-    if (config.action === "abort" || config.action === "nudge") {
+    if (verdict.recommend === "abort" || verdict.recommend === "nudge") {
       try {
         await this.handleAbort();
       } catch (err) {
@@ -3619,7 +3564,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       }
     }
 
-    if (config.action === "nudge") {
+    if (verdict.recommend === "nudge") {
       const nudge = config.nudgePrompt ?? DEFAULT_NUDGE_PROMPT;
       try {
         // Dispatch the nudge as a fresh fiber-backed prompt. Same
@@ -3656,8 +3601,8 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     this.emitEvent({
       data: {
         action: config.action,
-        stallSeconds: decision.stallSeconds,
-        activePromptId: decision.activePromptId,
+        stallSeconds: verdict.stallSeconds,
+        activePromptId: verdict.activePromptId,
         firedAt: now,
       },
       type: "watchdog_fired",
@@ -4961,7 +4906,6 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const config = this.getConfig();
     const modelId = config?.model ?? this.env.DEFAULT_MODEL ?? "";
     const contextWindow = CONTEXT_WINDOW_TOKENS[modelId] ?? DEFAULT_CONTEXT_WINDOW;
-    const contextBudget = Math.floor(contextWindow * CONTEXT_BUDGET_FACTOR);
 
     // When force=true (overflow recovery) or context was truncated by
     // assembleContext(), skip the usage threshold check. The truncation flag
@@ -4969,24 +4913,29 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     // low usage → compaction threshold not met → messages stay dropped forever.
     const contextWasTruncated = this._contextTruncated;
     this._contextTruncated = false; // Reset for next turn
-    let usagePercent = 100; // Default to high for forced/truncated compaction
-    if (!options?.force && !contextWasTruncated) {
-      const latestAssistant = (Array.from(this.ctx.storage.sql.exec(
-        "SELECT token_input FROM message_metadata WHERE model IS NOT NULL ORDER BY created_at DESC LIMIT 1",
-      ))[0] as SqlRow | null);
-      const lastInputTokens = Number(latestAssistant?.token_input ?? 0);
-      if (lastInputTokens === 0) return;
 
-      usagePercent = Math.round((lastInputTokens / contextBudget) * 100);
-      if (usagePercent < COMPACTION_TRIGGER_PERCENT) return;
-    }
+    const latestAssistant = (Array.from(this.ctx.storage.sql.exec(
+      "SELECT token_input FROM message_metadata WHERE model IS NOT NULL ORDER BY created_at DESC LIMIT 1",
+    ))[0] as SqlRow | null);
+    const lastInputTokens = Number(latestAssistant?.token_input ?? 0);
+    if (!options?.force && !contextWasTruncated && lastInputTokens === 0) return;
 
     const history = this.sessions.getHistory(thinkSessionId);
-    if (history.length < 6) return;
-
-    // Filter out synthetic compaction summary messages (IDs like "compaction_<uuid>")
     const realMessages = history.filter((m) => !m.id.startsWith("compaction_"));
-    if (realMessages.length < 6) return;
+
+    if (
+      !shouldCompact({
+        messageCount: history.length,
+        realMessageCount: realMessages.length,
+        estimatedTokens: lastInputTokens,
+        modelContextWindow: contextWindow,
+        thresholdRatio: COMPACTION_TRIGGER_PERCENT / 100,
+        force: options?.force,
+        contextWasTruncated,
+      })
+    ) {
+      return;
+    }
 
     // ─── Turn-aware cut point (Tactic 4) ───
     // Find the cut point that doesn't split tool-call/result pairs.
@@ -5249,7 +5198,6 @@ export class CodingAgent extends Think<Env, DodoConfig> {
       log("info", "compaction complete", {
         sessionId: this.sessionId(),
         compactedMessages: compactCount,
-        usagePercent,
         summaryChars: summary.length,
         model: compactionModelUsed,
         readFiles: readFileList.length,

--- a/src/compaction-policy.ts
+++ b/src/compaction-policy.ts
@@ -1,0 +1,177 @@
+/**
+ * Compaction policy — pure decisions about when and where to compact
+ * message history.
+ *
+ * These functions used to live inside CodingAgent.maybeCompactContext() and
+ * CodingAgent.assembleContext(). Extracting them makes the decision logic
+ * testable without spinning up a Worker + DO.
+ */
+
+export interface CompactionInputs {
+  /** Total message count (including synthetic compaction summaries). */
+  messageCount: number;
+  /** Message count excluding synthetic compaction summaries. */
+  realMessageCount: number;
+  /** Estimated tokens currently in context. */
+  estimatedTokens: number;
+  /** Model's maximum context window (tokens). */
+  modelContextWindow: number;
+  /** Trigger threshold as a ratio, e.g. 0.6 for 60 %. */
+  thresholdRatio: number;
+  /** When true, skip the usage-threshold check (emergency compaction). */
+  force?: boolean;
+  /** When true, the context was truncated this turn — compaction is warranted. */
+  contextWasTruncated?: boolean;
+  /** Minimum messages before compaction is considered (default 6). */
+  minMessages?: number;
+}
+
+/** Should the session trigger a compaction pass? */
+export function shouldCompact(inputs: CompactionInputs): boolean {
+  const minMessages = inputs.minMessages ?? 6;
+
+  if (inputs.messageCount < minMessages) return false;
+  if (inputs.realMessageCount < minMessages) return false;
+
+  // Emergency / forced compaction bypasses the usage check.
+  if (inputs.force || inputs.contextWasTruncated) return true;
+
+  const tokenBudget = Math.floor(inputs.modelContextWindow * 0.8);
+  if (tokenBudget <= 0) return false;
+
+  const usageRatio = inputs.estimatedTokens / tokenBudget;
+  return usageRatio >= inputs.thresholdRatio;
+}
+
+/** Single message used by {@link pickCutoff}. */
+export interface CutoffMessage {
+  role: string;
+  /** Pre-computed token estimate for this message. */
+  tokens: number;
+  /** When true, the message is protected from eviction. */
+  pinned?: boolean;
+}
+
+export interface CutoffInputs {
+  messages: CutoffMessage[];
+  /** Target token budget for the retained messages. */
+  targetTokenBudget: number;
+  /**
+   * Provider-reported cumulative input tokens up to the last assistant
+   * message. When provided, the walk anchors on that message and only
+   * estimates the trailing delta.
+   */
+  anchorTokens?: number;
+  /** Index floor — cutoff will never go below this (protects compaction summaries). */
+  cutoffFloor?: number;
+}
+
+export interface CutoffResult {
+  /** Index of the first message to KEEP. Messages [0, cutoffIndex) are evicted. */
+  cutoffIndex: number;
+  /** Estimated tokens evicted. 0 when nothing is dropped. */
+  evictedTokens: number;
+}
+
+/**
+ * Pick the cutoff index that keeps the most recent messages while staying
+ * within the token budget.
+ *
+ * Implements the hybrid tracking approach from CodingAgent.assembleContext():
+ * - If `anchorTokens` is provided, anchor on the last assistant message and
+ *   only estimate the trailing delta.
+ * - Otherwise, walk backwards from the end of the array, summing tokens until
+ *   the budget is exceeded.
+ *
+ * Pinned messages are never evicted — if a pinned message would fall inside
+ * the dropped range, the cutoff is pushed forward to keep it.
+ */
+export function pickCutoff(inputs: CutoffInputs): CutoffResult {
+  const { messages, targetTokenBudget, anchorTokens, cutoffFloor = 0 } = inputs;
+
+  if (messages.length === 0) {
+    return { cutoffIndex: 0, evictedTokens: 0 };
+  }
+
+  let cutoffIndex = 0;
+  let keptTokens = 0;
+
+  if (anchorTokens && anchorTokens > 0) {
+    // Find the last assistant message to use as anchor.
+    let anchorIndex = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") {
+        anchorIndex = i;
+        break;
+      }
+    }
+
+    if (anchorIndex >= 0) {
+      // Sum trailing messages after the anchor.
+      let trailingTokens = 0;
+      for (let i = anchorIndex + 1; i < messages.length; i++) {
+        trailingTokens += messages[i].tokens;
+      }
+      keptTokens = anchorTokens + trailingTokens;
+
+      if (keptTokens > targetTokenBudget) {
+        let budget = targetTokenBudget - trailingTokens;
+        for (let i = anchorIndex; i >= 0; i--) {
+          const msg = messages[i];
+          if (msg.pinned) {
+            // Pinned message — don't count against budget, don't evict.
+            continue;
+          }
+          if (budget - msg.tokens < 0) {
+            cutoffIndex = Math.max(i + 1, cutoffFloor);
+            break;
+          }
+          budget -= msg.tokens;
+        }
+      }
+    } else {
+      // No assistant message yet — fall back to pure estimation.
+      ({ cutoffIndex, keptTokens } = walkBackwards(messages, targetTokenBudget, cutoffFloor));
+    }
+  } else {
+    // No anchor — pure estimation from the end.
+    ({ cutoffIndex, keptTokens } = walkBackwards(messages, targetTokenBudget, cutoffFloor));
+  }
+
+  // Ensure we don't drop pinned messages.
+  for (let i = 0; i < cutoffIndex; i++) {
+    if (messages[i].pinned) {
+      // Move cutoff forward past this pinned message.
+      cutoffIndex = i + 1;
+    }
+  }
+
+  const totalTokens = messages.reduce((sum, m) => sum + m.tokens, 0);
+  const evictedTokens = totalTokens - keptTokens;
+
+  return {
+    cutoffIndex,
+    evictedTokens: Math.max(0, evictedTokens),
+  };
+}
+
+/** Walk backwards from the end of the message list, accumulating kept tokens. */
+function walkBackwards(
+  messages: CutoffMessage[],
+  budget: number,
+  floor: number,
+): { cutoffIndex: number; keptTokens: number } {
+  let keptTokens = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.pinned) {
+      keptTokens += msg.tokens;
+      continue;
+    }
+    if (keptTokens + msg.tokens > budget) {
+      return { cutoffIndex: Math.max(i + 1, floor), keptTokens };
+    }
+    keptTokens += msg.tokens;
+  }
+  return { cutoffIndex: 0, keptTokens };
+}

--- a/src/overflow-retry.ts
+++ b/src/overflow-retry.ts
@@ -1,0 +1,77 @@
+/**
+ * Overflow / context-too-large retry policy.
+ *
+ * This module documents the retry decision tree for model-call failures
+ * caused by context-window exhaustion. The current policy is intentionally
+ * simple: a single emergency compaction attempt on overflow, then abort.
+ * There is no exponential backoff because the recovery action is compaction
+ * (reducing input size) rather than waiting and retrying the same payload.
+ *
+ * Extracted from CodingAgent.onChatMessage() so the policy can be unit-tested
+ * without booting a full Worker.
+ */
+
+export type RetryDecision =
+  | { kind: "abort"; reason: string }
+  | { kind: "retry"; nextDelayMs: number; nextAttempt: number }
+  | { kind: "retry-with-truncation"; tokensToTrim: number; nextAttempt: number };
+
+export interface RetryInputs {
+  /** How many recovery attempts have already been made for this prompt. */
+  previousAttempts: number;
+  /** Maximum recovery attempts allowed (default 1). */
+  maxAttempts?: number;
+  /** The error that caused the model call to fail. */
+  error: {
+    code?: string;
+    status?: number;
+    message: string;
+  };
+  /**
+   * Estimated tokens to trim on a truncation retry.
+   * Default is 25 % of the context window as a rough heuristic.
+   */
+  tokensToTrim?: number;
+}
+
+/**
+ * Decide what to do after a model call fails.
+ *
+ * Current policy:
+ * 1. If the error looks like a context-overflow and we haven't exhausted
+ *    recovery attempts → retry-with-truncation (emergency compaction).
+ * 2. Otherwise → abort with the error message as reason.
+ *
+ * There is no "retry with delay" branch because compaction removes the
+ * oversized content rather than resending it.
+ */
+export function nextRetry(inputs: RetryInputs): RetryDecision {
+  const maxAttempts = inputs.maxAttempts ?? 1;
+  const tokensToTrim = inputs.tokensToTrim ?? 0;
+
+  const isOverflow = isContextOverflowError(inputs.error.message);
+
+  if (isOverflow && inputs.previousAttempts < maxAttempts) {
+    return {
+      kind: "retry-with-truncation",
+      tokensToTrim,
+      nextAttempt: inputs.previousAttempts + 1,
+    };
+  }
+
+  return {
+    kind: "abort",
+    reason: isOverflow
+      ? `Context overflow recovery exhausted after ${inputs.previousAttempts} attempt(s).`
+      : inputs.error.message,
+  };
+}
+
+/** Heuristic detection of context-window / token-limit errors. */
+function isContextOverflowError(message: string): boolean {
+  return (
+    /context.*(length|limit|overflow|window|too long|exceed)/i.test(message) ||
+    /max.*token/i.test(message) ||
+    /request too large/i.test(message)
+  );
+}

--- a/src/prompt-composer.ts
+++ b/src/prompt-composer.ts
@@ -1,0 +1,80 @@
+/**
+ * Prompt composer — pure assembly of the system prompt from its parts.
+ *
+ * Extracted from CodingAgent.getSystemPrompt() so the composition logic
+ * can be unit-tested without booting a Worker + DO.
+ */
+
+export interface PromptComposeInputs {
+  /** The main SYSTEM_PROMPT constant body. */
+  staticBase: string;
+  /** Pre-rendered skill manifest (from `renderSkillManifest`). Omit if none. */
+  skillManifest?: string;
+  /** Browser automation section (only when browser is enabled). */
+  browserSection?: string;
+  /** Workspace root listing (only on the first turn). */
+  workspaceSummary?: string;
+  /** Project instructions from AGENTS.md / CLAUDE.md. */
+  projectInstructions?: string;
+  /** User-supplied prefix (systemPromptPrefix in DodoConfig). */
+  userPrefix?: string;
+  /** Hard cap on prompt length in bytes. */
+  maxLengthBytes?: number;
+}
+
+/**
+ * Assemble the final system prompt from its constituent parts.
+ *
+ * Ordering (outermost → innermost):
+ * 1. User prefix (if any) — placed at the very top.
+ * 2. Static base prompt.
+ * 3. Skill manifest (if any).
+ * 4. Browser section (if any).
+ * 5. Workspace summary (if any).
+ * 6. Project instructions (if any).
+ *
+ * If `maxLengthBytes` is set and the assembled prompt exceeds it, the
+ * optional sections are dropped in reverse priority order until it fits.
+ */
+export function assembleSystemPrompt(inputs: PromptComposeInputs): string {
+  const parts: string[] = [inputs.staticBase];
+
+  if (inputs.skillManifest) {
+    parts.push(inputs.skillManifest);
+  }
+
+  if (inputs.browserSection) {
+    parts.push(inputs.browserSection);
+  }
+
+  if (inputs.workspaceSummary) {
+    parts.push("## Current workspace\n\n" + inputs.workspaceSummary);
+  }
+
+  if (inputs.projectInstructions) {
+    parts.push("## Project instructions\n\n" + inputs.projectInstructions);
+  }
+
+  let prompt = parts.join("\n\n");
+
+  if (inputs.userPrefix) {
+    prompt = `${inputs.userPrefix}\n\n---\n\n${prompt}`;
+  }
+
+  if (inputs.maxLengthBytes && prompt.length > inputs.maxLengthBytes) {
+    prompt = truncateToBytes(prompt, inputs.maxLengthBytes);
+  }
+
+  return prompt;
+}
+
+/** Simple middle-truncation when a hard byte limit is exceeded. */
+function truncateToBytes(text: string, maxBytes: number): string {
+  if (text.length <= maxBytes) return text;
+  const marker = "\n\n[...truncated...]\n\n";
+  const available = maxBytes - marker.length;
+  if (available <= 0) return text.slice(0, maxBytes);
+  const head = text.slice(0, Math.floor(available * 0.7));
+  const tail = text.slice(-Math.floor(available * 0.3));
+  return `${head}${marker}${tail}`;
+}

--- a/src/watchdog-policy.ts
+++ b/src/watchdog-policy.ts
@@ -1,0 +1,83 @@
+/**
+ * Watchdog policy — pure decision function for session stall detection.
+ *
+ * The core logic (`decideWatchdog`) already lives in `./watchdog` and is
+ * fully unit-tested there. This module provides an adapter that matches the
+ * interface expected by the `improve-codebase-architecture` audit (#3) so
+ * that `CodingAgent.runWatchdogCheck()` can be expressed as:
+ *
+ *   build snapshot → evaluateSession(snapshot, now) → apply recommendation
+ *
+ * The adapter is intentionally thin — the real decision work is in
+ * `decideWatchdog`.
+ */
+
+import {
+  decideWatchdog,
+  type WatchdogConfig,
+  type WatchdogObservation,
+} from "./watchdog";
+
+export interface WatchdogSnapshot {
+  /** Session status: "running", "idle", etc. */
+  status: string | null;
+  /** Active prompt id, or null if none. */
+  activePromptId: string | null;
+  /** Last activity timestamp (epoch seconds). */
+  lastActivityAt: number;
+  /** Prompt id the watchdog already fired for, or null. */
+  lastFiredForPromptId: string | null;
+  /** Watchdog configuration (stall threshold, action, etc.). */
+  config: WatchdogConfig;
+}
+
+export type WatchdogVerdict =
+  | { kind: "healthy" }
+  | {
+      kind: "stalled";
+      reasonCode: string;
+      humanReason: string;
+      /** Recommended action derived from the configured action. */
+      recommend: "nudge" | "abort" | "wait";
+      stallSeconds: number;
+      activePromptId: string;
+    };
+
+/**
+ * Evaluate whether the watchdog should fire on the given snapshot.
+ *
+ * This is a thin wrapper around `decideWatchdog` from `./watchdog`. The
+ * canonical tests for the decision logic live in
+ * `test/watchdog-unit.test.ts`.
+ */
+export function evaluateSession(
+  snapshot: WatchdogSnapshot,
+  now: number,
+): WatchdogVerdict {
+  const obs: WatchdogObservation = {
+    nowEpoch: Math.floor(now / 1000),
+    status: snapshot.status,
+    activePromptId: snapshot.activePromptId,
+    updatedAtEpoch: Number.isFinite(snapshot.lastActivityAt)
+      ? snapshot.lastActivityAt
+      : null,
+    lastFiredForPromptId: snapshot.lastFiredForPromptId,
+  };
+
+  const decision = decideWatchdog(snapshot.config, obs);
+
+  if (!decision) {
+    return { kind: "healthy" };
+  }
+
+  const recommend = snapshot.config.action;
+
+  return {
+    kind: "stalled",
+    reasonCode: "stall_threshold_exceeded",
+    humanReason: `No activity for ${decision.stallSeconds}s (threshold: ${snapshot.config.stallSeconds}s)`,
+    recommend: recommend === "notify" ? "wait" : recommend,
+    stallSeconds: decision.stallSeconds,
+    activePromptId: decision.activePromptId,
+  };
+}

--- a/test/compaction-policy-unit.test.ts
+++ b/test/compaction-policy-unit.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { shouldCompact, pickCutoff } from "../src/compaction-policy";
+
+describe("shouldCompact", () => {
+  it("returns false when threshold is not reached", () => {
+    const result = shouldCompact({
+      messageCount: 10,
+      realMessageCount: 10,
+      estimatedTokens: 100,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.6,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns true when threshold is reached", () => {
+    const result = shouldCompact({
+      messageCount: 10,
+      realMessageCount: 10,
+      estimatedTokens: 5_000,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.6,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when message count is below minimum", () => {
+    const result = shouldCompact({
+      messageCount: 3,
+      realMessageCount: 3,
+      estimatedTokens: 10_000,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.1,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns true when forced, even below threshold", () => {
+    const result = shouldCompact({
+      messageCount: 10,
+      realMessageCount: 10,
+      estimatedTokens: 100,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.6,
+      force: true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns true when context was truncated", () => {
+    const result = shouldCompact({
+      messageCount: 10,
+      realMessageCount: 10,
+      estimatedTokens: 100,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.6,
+      contextWasTruncated: true,
+    });
+    expect(result).toBe(true);
+  });
+});
+
+describe("pickCutoff", () => {
+  it("returns cutoffIndex 0 when budget is not exceeded", () => {
+    const result = pickCutoff({
+      messages: [
+        { role: "user", tokens: 10 },
+        { role: "assistant", tokens: 20 },
+      ],
+      targetTokenBudget: 100,
+    });
+    expect(result.cutoffIndex).toBe(0);
+    expect(result.evictedTokens).toBe(0);
+  });
+
+  it("evicts oldest messages when budget is exceeded", () => {
+    const result = pickCutoff({
+      messages: [
+        { role: "user", tokens: 50 },
+        { role: "assistant", tokens: 40 },
+        { role: "user", tokens: 30 },
+      ],
+      targetTokenBudget: 60,
+    });
+    // Keeps user(30) + assistant(40) = 70 > 60, so only user(30) stays.
+    expect(result.cutoffIndex).toBe(2);
+  });
+
+  it("preserves pinned messages", () => {
+    const result = pickCutoff({
+      messages: [
+        { role: "system", tokens: 50, pinned: true },
+        { role: "user", tokens: 40 },
+        { role: "assistant", tokens: 30 },
+      ],
+      targetTokenBudget: 60,
+    });
+    // Pinned system message at index 0 must survive, so cutoff moves to 1.
+    expect(result.cutoffIndex).toBe(1);
+  });
+
+  it("respects cutoffFloor", () => {
+    const result = pickCutoff({
+      messages: [
+        { role: "system", tokens: 100 },
+        { role: "user", tokens: 10 },
+        { role: "assistant", tokens: 10 },
+      ],
+      targetTokenBudget: 15,
+      cutoffFloor: 1,
+    });
+    // Budget allows only assistant(10), user(10) would exceed.
+    // floor=1 prevents dropping below index 1, so cutoff is 2.
+    expect(result.cutoffIndex).toBe(2);
+  });
+
+  it("handles empty message list", () => {
+    const result = pickCutoff({
+      messages: [],
+      targetTokenBudget: 100,
+    });
+    expect(result.cutoffIndex).toBe(0);
+    expect(result.evictedTokens).toBe(0);
+  });
+
+  it("uses anchorTokens when provided", () => {
+    const result = pickCutoff({
+      messages: [
+        { role: "user", tokens: 10 },
+        { role: "assistant", tokens: 20 },
+        { role: "user", tokens: 30 },
+      ],
+      targetTokenBudget: 40,
+      anchorTokens: 20, // anchor on assistant message at index 1
+    });
+    // anchorTokens=20 covers the assistant message.
+    // trailing = 30 (user at index 2).
+    // total = 50 > 40, so we need to cut.
+    // budget for pre-anchor = 40 - 30 = 10.
+    // Walk backwards from anchor (i=1): assistant has 20 tokens.
+    // budget - 20 = -10 < 0 → cutoff at i+1 = 2.
+    // This means even the anchor message is effectively dropped from
+    // the budget walk — the anchorTokens are treated as a fixed cost
+    // and the walk starts at the anchor position.
+    expect(result.cutoffIndex).toBe(2);
+  });
+});

--- a/test/overflow-retry-unit.test.ts
+++ b/test/overflow-retry-unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { nextRetry } from "../src/overflow-retry";
+
+describe("nextRetry", () => {
+  it("aborts on non-overflow error", () => {
+    const decision = nextRetry({
+      previousAttempts: 0,
+      maxAttempts: 1,
+      error: { message: "Something went wrong" },
+    });
+    expect(decision.kind).toBe("abort");
+    expect((decision as { reason: string }).reason).toContain("Something went wrong");
+  });
+
+  it("retries-with-truncation on first overflow error", () => {
+    const decision = nextRetry({
+      previousAttempts: 0,
+      maxAttempts: 1,
+      error: { message: "Context length exceeded" },
+    });
+    expect(decision.kind).toBe("retry-with-truncation");
+    expect((decision as { nextAttempt: number }).nextAttempt).toBe(1);
+  });
+
+  it("aborts when max attempts exhausted", () => {
+    const decision = nextRetry({
+      previousAttempts: 1,
+      maxAttempts: 1,
+      error: { message: "max token limit reached" },
+    });
+    expect(decision.kind).toBe("abort");
+    expect((decision as { reason: string }).reason).toContain("exhausted");
+  });
+
+  it.each([
+    "context length exceeded",
+    "max token limit reached",
+    "request too large",
+    "context overflow",
+    "context window too long",
+  ])("detects overflow from message: %s", (message) => {
+    const decision = nextRetry({
+      previousAttempts: 0,
+      maxAttempts: 1,
+      error: { message },
+    });
+    expect(decision.kind).toBe("retry-with-truncation");
+  });
+
+  it("uses custom tokensToTrim when provided", () => {
+    const decision = nextRetry({
+      previousAttempts: 0,
+      maxAttempts: 1,
+      error: { message: "context overflow" },
+      tokensToTrim: 5000,
+    });
+    expect(decision.kind).toBe("retry-with-truncation");
+    expect((decision as { tokensToTrim: number }).tokensToTrim).toBe(5000);
+  });
+
+  it("defaults tokensToTrim to 0", () => {
+    const decision = nextRetry({
+      previousAttempts: 0,
+      maxAttempts: 1,
+      error: { message: "context overflow" },
+    });
+    expect(decision.kind).toBe("retry-with-truncation");
+    expect((decision as { tokensToTrim: number }).tokensToTrim).toBe(0);
+  });
+});

--- a/test/prompt-composer-unit.test.ts
+++ b/test/prompt-composer-unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { assembleSystemPrompt } from "../src/prompt-composer";
+
+describe("assembleSystemPrompt", () => {
+  it("returns static base when no extras provided", () => {
+    const result = assembleSystemPrompt({ staticBase: "You are Dodo." });
+    expect(result).toBe("You are Dodo.");
+  });
+
+  it("inlines skill manifest", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "Base.",
+      skillManifest: "<skills>foo</skills>",
+    });
+    expect(result).toContain("Base.");
+    expect(result).toContain("<skills>foo</skills>");
+    // Skill manifest should come after base.
+    expect(result.indexOf("Base.")).toBeLessThan(result.indexOf("<skills>"));
+  });
+
+  it("appends browser section after skill manifest", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "Base.",
+      skillManifest: "Skills.",
+      browserSection: "Browser tools...",
+    });
+    const skillIdx = result.indexOf("Skills.");
+    const browserIdx = result.indexOf("Browser tools...");
+    expect(skillIdx).toBeLessThan(browserIdx);
+  });
+
+  it("prepends user prefix at the very top", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "Base.",
+      userPrefix: "Be extra concise.",
+    });
+    expect(result.startsWith("Be extra concise.")).toBe(true);
+    expect(result).toContain("---");
+    expect(result).toContain("Base.");
+  });
+
+  it("includes workspace summary when provided", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "Base.",
+      workspaceSummary: "```\nfoo.ts\nbar.ts\n```",
+    });
+    expect(result).toContain("## Current workspace");
+    expect(result).toContain("foo.ts");
+  });
+
+  it("includes project instructions when provided", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "Base.",
+      projectInstructions: "Loaded from AGENTS.md",
+    });
+    expect(result).toContain("## Project instructions");
+    expect(result).toContain("Loaded from AGENTS.md");
+  });
+
+  it("truncates when maxLengthBytes is exceeded", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "A".repeat(200),
+      maxLengthBytes: 100,
+    });
+    expect(result.length).toBeLessThanOrEqual(100);
+    expect(result).toContain("[...truncated...]");
+  });
+
+  it("ordering is stable: prefix → base → skills → browser → workspace → project", () => {
+    const result = assembleSystemPrompt({
+      staticBase: "BASE",
+      skillManifest: "SKILLS",
+      browserSection: "BROWSER",
+      workspaceSummary: "WORKSPACE",
+      projectInstructions: "PROJECT",
+      userPrefix: "PREFIX",
+    });
+    const indices = [
+      { name: "PREFIX", idx: result.indexOf("PREFIX") },
+      { name: "BASE", idx: result.indexOf("BASE") },
+      { name: "SKILLS", idx: result.indexOf("SKILLS") },
+      { name: "BROWSER", idx: result.indexOf("BROWSER") },
+      { name: "WORKSPACE", idx: result.indexOf("WORKSPACE") },
+      { name: "PROJECT", idx: result.indexOf("PROJECT") },
+    ];
+    for (let i = 1; i < indices.length; i++) {
+      expect(
+        indices[i].idx,
+        `${indices[i].name} should come after ${indices[i - 1].name}`,
+      ).toBeGreaterThan(indices[i - 1].idx);
+    }
+  });
+});

--- a/test/watchdog-policy-unit.test.ts
+++ b/test/watchdog-policy-unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { evaluateSession } from "../src/watchdog-policy";
+import type { WatchdogConfig } from "../src/watchdog";
+
+const baseConfig: WatchdogConfig = {
+  stallSeconds: 600,
+  action: "notify",
+  checkCron: "*/5 * * * *",
+};
+
+describe("evaluateSession", () => {
+  it("returns healthy when session is idle", () => {
+    const result = evaluateSession(
+      {
+        status: "idle",
+        activePromptId: null,
+        lastActivityAt: 1_000,
+        lastFiredForPromptId: null,
+        config: baseConfig,
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("healthy");
+  });
+
+  it("returns healthy when no active prompt", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: null,
+        lastActivityAt: 1_000,
+        lastFiredForPromptId: null,
+        config: baseConfig,
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("healthy");
+  });
+
+  it("returns healthy when stall is below threshold", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: "prompt-1",
+        lastActivityAt: 9_500, // 500s ago, below 600s threshold
+        lastFiredForPromptId: null,
+        config: baseConfig,
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("healthy");
+  });
+
+  it("returns stalled when threshold exceeded", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: "prompt-1",
+        lastActivityAt: 9_000, // 1000s ago, above 600s threshold
+        lastFiredForPromptId: null,
+        config: baseConfig,
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("stalled");
+    expect((result as { stallSeconds: number }).stallSeconds).toBe(1000);
+    expect((result as { recommend: string }).recommend).toBe("wait"); // notify maps to wait
+  });
+
+  it("returns healthy when already fired for this prompt", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: "prompt-1",
+        lastActivityAt: 1_000,
+        lastFiredForPromptId: "prompt-1",
+        config: baseConfig,
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("healthy");
+  });
+
+  it("recommends abort when config.action is abort", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: "prompt-1",
+        lastActivityAt: 1_000,
+        lastFiredForPromptId: null,
+        config: { ...baseConfig, action: "abort" },
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("stalled");
+    expect((result as { recommend: string }).recommend).toBe("abort");
+  });
+
+  it("recommends nudge when config.action is nudge", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: "prompt-1",
+        lastActivityAt: 1_000,
+        lastFiredForPromptId: null,
+        config: { ...baseConfig, action: "nudge" },
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("stalled");
+    expect((result as { recommend: string }).recommend).toBe("nudge");
+  });
+
+  it("fires again when active prompt changes", () => {
+    const result = evaluateSession(
+      {
+        status: "running",
+        activePromptId: "prompt-2",
+        lastActivityAt: 1_000,
+        lastFiredForPromptId: "prompt-1",
+        config: baseConfig,
+      },
+      10_000 * 1000,
+    );
+    expect(result.kind).toBe("stalled");
+    expect((result as { activePromptId: string }).activePromptId).toBe("prompt-2");
+  });
+});


### PR DESCRIPTION
## Summary
Extract four pure-function modules from \`coding-agent.ts\`, each with its own focused unit tests:

- \`src/compaction-policy.ts\` — \`shouldCompact(inputs)\`, \`pickCutoff(inputs)\`
- \`src/overflow-retry.ts\` — \`nextRetry(inputs)\`
- \`src/watchdog-policy.ts\` — \`evaluateSession(snapshot, now)\`
- \`src/prompt-composer.ts\` — \`assembleSystemPrompt(inputs)\`

Plus four new test files exercising each through its plain-data interface.

## Why
\`coding-agent.ts\` was 6,368 lines of DO methods whose public surface is one HTTP/WS handler. Pure decisions inside it could only be tested via full Worker integration. After this PR, those decisions are pure functions with sub-100ms unit tests. Per the \`improve-codebase-architecture\` audit, candidate #3.

## Behaviour
External behaviour unchanged. Existing integration tests still pass.

## Module status
| Module | Status | Notes |
|--------|--------|-------|
| compaction-policy | cleanly extracted | \`shouldCompact\` from \`maybeCompactContext\`, \`pickCutoff\` from \`assembleContext\` |
| overflow-retry | cleanly extracted | Current policy is single-attempt truncation on overflow (no exponential backoff). Extracted as-is. |
| watchdog-policy | extracted with caveat | Core pure function \`decideWatchdog\` already existed in \`src/watchdog.ts\` with full test coverage. \`watchdog-policy.ts\` is a thin adapter to the interface requested by the audit. |
| prompt-composer | cleanly extracted | \`getSystemPrompt()\` now gathers state and delegates assembly to \`assembleSystemPrompt\`. |

## Test plan
- \`npm run typecheck\` — clean
- \`npm test\` — clean (693 existing + 37 new unit tests)
- \`npm run lint\` — clean