### PR TITLE
feat(ui): surface skills and tool catalog in sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -823,6 +823,16 @@
           </details>
         </div>
         <div class="section">
+          <h2>Skills</h2>
+          <p style="font-size:11px;color:var(--muted);margin-bottom:6px">Skills are SKILL.md files the agent loads on demand. Built-in skills ship with Dodo; personal skills you author here. Workspace skills (per-session, from <code>.dodo/skills/</code> etc.) are not shown here.</p>
+          <div id="skills-list"></div>
+        </div>
+        <div class="section">
+          <h2>Tools</h2>
+          <p style="font-size:11px;color:var(--muted);margin-bottom:6px">Always-on tools available to the agent. Configure MCP integrations below to add more.</p>
+          <div id="tool-catalog-list"></div>
+        </div>
+        <div class="section">
           <h2>Integrations</h2>
           <div id="integrations-list"></div>
           <details style="margin-top:6px">
@@ -996,7 +1006,7 @@
     // --- Boot ---
     async function boot(){
       const isSharedSession=location.hash.match(/^#session=(.+)$/);
-      const bootTasks=[loadIdentity(),loadSessions(),loadConfig(),loadAllowlist(),loadMemory(),loadModels(),loadStatus(),loadTasks(),loadPasskeyStatus(),loadSecrets(),loadIntegrations(),loadBrowserConfig()];
+      const bootTasks=[loadIdentity(),loadSessions(),loadConfig(),loadAllowlist(),loadMemory(),loadModels(),loadStatus(),loadTasks(),loadPasskeyStatus(),loadSecrets(),loadIntegrations(),loadBrowserConfig(),loadSkillsAndTools()];
       if(!isSharedSession)bootTasks.push(checkOnboarding());
       await Promise.all(bootTasks);
       startTaskSync();

--- a/public/js/dodo-settings.js
+++ b/public/js/dodo-settings.js
@@ -423,3 +423,62 @@ async function removeSessionMcpOverride(mcpId){
     await loadSessionMcpConfigs();
   }catch(e){toast("Failed: "+(e.message||e),"error")}
 }
+
+// --- Skills & Tools catalog ---
+async function loadSkillsAndTools(){
+  const skillsEl=$("skills-list");
+  const toolsEl=$("tool-catalog-list");
+  if(!skillsEl&&!toolsEl)return;
+  try{
+    const[skillsRes,toolsRes]=await Promise.all([
+      api("/api/skills/all").catch(()=>({skills:[]})),
+      api("/api/tool-catalog").catch(()=>({orchestrator:[],subagent:[]})),
+    ]);
+    renderSkillCatalog(skillsRes.skills||[]);
+    renderToolCatalog(toolsRes.orchestrator||[]);
+  }catch(e){
+    if(skillsEl)skillsEl.innerHTML='<div class="empty">Failed to load skills</div>';
+    if(toolsEl)toolsEl.innerHTML='<div class="empty">Failed to load tools</div>';
+  }
+}
+
+function renderSkillCatalog(skills){
+  const el=$("skills-list");if(!el)return;
+  if(!skills.length){el.innerHTML='<div class="empty">No skills available</div>';return}
+  // Group: built-in vs personal
+  const groups={builtin:[],personal:[]};
+  for(const s of skills){(groups[s.source]||groups.personal).push(s)}
+  const renderRow=s=>{
+    const badge=s.source==="builtin"
+      ?'<span class="integ-status" style="color:var(--text-subtle);font-size:10px">built-in</span>'
+      :`<span class="integ-status" style="color:${s.enabled?'var(--text-success)':'var(--text-subtle)'};font-size:10px">${s.enabled?'enabled':'disabled'}</span>`;
+    return `<div class="integ-card"><div class="integ-name">${esc(s.name)}</div><div class="integ-desc">${esc(s.description||"")}</div>${badge}</div>`;
+  };
+  const sections=[];
+  if(groups.personal.length){
+    sections.push(`<div style="font-size:11px;color:var(--text-subtle);margin:6px 0 4px">Personal (${groups.personal.length})</div>${groups.personal.map(renderRow).join("")}`);
+  }
+  if(groups.builtin.length){
+    sections.push(`<div style="font-size:11px;color:var(--text-subtle);margin:6px 0 4px">Built-in (${groups.builtin.length})</div>${groups.builtin.map(renderRow).join("")}`);
+  }
+  el.innerHTML=sections.join("");
+}
+
+function renderToolCatalog(tools){
+  const el=$("tool-catalog-list");if(!el)return;
+  if(!tools.length){el.innerHTML='<div class="empty">No tools available</div>';return}
+  // Group by category for readability
+  const order=["subagent","discovery","files","edit","planning","skill","execution","git"];
+  const labels={subagent:"Subagents",discovery:"Discovery",files:"Files",edit:"Edit",planning:"Planning",skill:"Skills",execution:"Execution",git:"Git"};
+  const byCat={};
+  for(const t of tools){(byCat[t.category]=byCat[t.category]||[]).push(t)}
+  const sections=order.filter(c=>byCat[c]&&byCat[c].length).map(cat=>{
+    const items=byCat[cat].map(t=>{
+      const dim=t.alwaysOn?"":";opacity:0.6";
+      const caveat=t.caveat?` <span style="color:var(--text-subtle);font-style:italic">(${esc(t.caveat)})</span>`:"";
+      return `<div class="integ-card" style="padding:6px 8px${dim}"><div style="display:flex;align-items:baseline;gap:6px"><code style="font-family:var(--mono);font-size:12px">${esc(t.name)}</code>${t.alwaysOn?"":'<span class="integ-status" style="font-size:10px;color:var(--text-subtle)">off</span>'}</div><div class="integ-desc" style="margin-top:2px">${esc(t.description)}${caveat}</div></div>`;
+    }).join("");
+    return `<div style="font-size:11px;color:var(--text-subtle);margin:6px 0 4px">${labels[cat]||cat}</div>${items}`;
+  });
+  el.innerHTML=sections.join("");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -795,6 +795,37 @@ app.get("/api/skills", async (c) => {
   return proxyToUserControl(c.env, email, `/skills${new URL(c.req.raw.url).search}`);
 });
 
+// Merged personal + built-in skill list. Registered BEFORE /api/skills/:name
+// so Hono doesn't route "/api/skills/all" as the GET-by-name handler.
+// Workspace skills are session-scoped (live inside the cloned repo) and are
+// intentionally excluded — they only resolve when the user has a session
+// selected. Surfaced for the Skills sidebar so users can see what their
+// agent knows without diving into the system prompt.
+app.get("/api/skills/all", async (c) => {
+  const email = c.get("userEmail");
+  const personalRes = await proxyToUserControl(c.env, email, "/skills");
+  const personalPayload = await personalRes.json() as { skills?: Array<Record<string, unknown>> };
+  const personal = (personalPayload.skills ?? []).map((s) => ({
+    name: String(s.name),
+    description: String(s.description ?? ""),
+    enabled: s.enabled !== false,
+    source: "personal" as const,
+  }));
+  const { listBuiltinSkills } = await import("./builtin-skills");
+  const builtin = listBuiltinSkills().map((s) => ({
+    name: s.name,
+    description: s.description,
+    enabled: true,
+    source: "builtin" as const,
+  }));
+  const personalNames = new Set(personal.map((s) => s.name));
+  const merged = [
+    ...personal,
+    ...builtin.filter((s) => !personalNames.has(s.name)),
+  ].sort((a, b) => a.name.localeCompare(b.name));
+  return c.json({ skills: merged });
+});
+
 app.post("/api/skills", async (c) => {
   const email = c.get("userEmail");
   return proxyToUserControl(c.env, email, "/skills", {
@@ -831,6 +862,16 @@ app.delete("/api/skills/:name", async (c) => {
   const email = c.get("userEmail");
   return proxyToUserControl(c.env, email, `/skills/${encodeURIComponent(c.req.param("name"))}`, {
     method: "DELETE",
+  });
+});
+
+// ─── Tool catalog (static, for UI surfacing) ───
+
+app.get("/api/tool-catalog", async (c) => {
+  const { getOrchestratorToolCatalog, getSubagentToolCatalog } = await import("./tool-catalog");
+  return c.json({
+    orchestrator: getOrchestratorToolCatalog(),
+    subagent: getSubagentToolCatalog(),
   });
 });
 

--- a/src/tool-catalog.ts
+++ b/src/tool-catalog.ts
@@ -1,0 +1,123 @@
+/**
+ * Static catalog of orchestrator tools, surfaced to:
+ *  - the UI (`GET /api/tool-catalog`) so users can see what their agent
+ *    can do without reading the system prompt
+ *  - documentation generators (future)
+ *
+ * This is a **descriptive** catalog, not the source of truth for actual
+ * tool registration — that lives in `src/agentic.ts` where each tool is
+ * wired with its full schema. Keep this list in sync when adding/removing
+ * tools. The cost of drift is small: the UI section under-promises if a
+ * tool was added without updating here, and over-promises if a tool was
+ * removed. A unit test (`test/tool-catalog-unit.test.ts`) checks that
+ * every catalog entry has a matching tool name registered in the system
+ * prompt's tool table.
+ */
+export interface ToolCatalogEntry {
+  /** Stable tool id used by the model. */
+  name: string;
+  /** One-line description for the UI. */
+  description: string;
+  /** Coarse grouping for UI sectioning. */
+  category:
+    | "discovery"
+    | "files"
+    | "edit"
+    | "planning"
+    | "git"
+    | "execution"
+    | "subagent"
+    | "skill";
+  /** True when the tool is always available regardless of session
+   *  configuration. False for tools gated on env/config (e.g. browser). */
+  alwaysOn: boolean;
+  /** Optional human-friendly note on when *not* to use this tool. */
+  caveat?: string;
+}
+
+const ORCHESTRATOR_TOOLS: ToolCatalogEntry[] = [
+  // Discovery (cheap, run-often)
+  {
+    name: "explore",
+    description:
+      "Search agent for codebase discovery — returns a compact summary in a separate context window.",
+    category: "subagent",
+    alwaysOn: true,
+    caveat:
+      "Falls back to direct read/grep when the subagent is unavailable.",
+  },
+  {
+    name: "task",
+    description:
+      "Delegate a bounded sub-task to a fresh subagent with read+write workspace tools.",
+    category: "subagent",
+    alwaysOn: true,
+  },
+  // File ops
+  { name: "read", description: "Read file contents with line offsets.", category: "files", alwaysOn: true },
+  { name: "list", description: "List directory entries.", category: "files", alwaysOn: true },
+  { name: "find", description: "Find files by glob.", category: "files", alwaysOn: true },
+  { name: "grep", description: "Search file contents by regex.", category: "files", alwaysOn: true },
+  { name: "write", description: "Create or overwrite a file.", category: "edit", alwaysOn: true },
+  { name: "edit", description: "Find-and-replace a unique snippet in one file.", category: "edit", alwaysOn: true },
+  { name: "replace_all", description: "Replace all occurrences of a string in one file.", category: "edit", alwaysOn: true },
+  { name: "delete", description: "Remove a file or directory.", category: "edit", alwaysOn: true },
+  // Planning
+  { name: "todo_list", description: "List session todos.", category: "planning", alwaysOn: true },
+  { name: "todo_add", description: "Append a todo.", category: "planning", alwaysOn: true },
+  { name: "todo_update", description: "Update a todo's status, content, or priority.", category: "planning", alwaysOn: true },
+  { name: "todo_clear", description: "Clear all todos.", category: "planning", alwaysOn: true },
+  // Skill loader
+  {
+    name: "skill",
+    description: "Load a SKILL.md by name to inject its instructions and assets.",
+    category: "skill",
+    alwaysOn: true,
+  },
+  // Code execution / typecheck
+  {
+    name: "codemode",
+    description:
+      "Execute JavaScript in a sandboxed dynamic worker against the session workspace.",
+    category: "execution",
+    alwaysOn: false,
+    caveat: "Requires codemode bindings to be configured.",
+  },
+  {
+    name: "typecheck",
+    description: "Run TypeScript `tsc --noEmit` against the workspace and return diagnostics.",
+    category: "execution",
+    alwaysOn: true,
+  },
+  // Git
+  { name: "git_clone", description: "Clone a git repo into the session workspace.", category: "git", alwaysOn: true },
+  { name: "git_clone_known", description: "Clone one of the built-in known repos by id.", category: "git", alwaysOn: true },
+  { name: "git_status", description: "Show working tree status.", category: "git", alwaysOn: true },
+  { name: "git_add", description: "Stage files.", category: "git", alwaysOn: true },
+  { name: "git_commit", description: "Commit staged changes.", category: "git", alwaysOn: true },
+  { name: "git_push", description: "Push commits to remote.", category: "git", alwaysOn: true },
+  { name: "git_push_checked", description: "Push with extra remote-state checks (no clobber).", category: "git", alwaysOn: true },
+  { name: "git_pull", description: "Pull from remote.", category: "git", alwaysOn: true },
+  { name: "git_branch", description: "List or create branches.", category: "git", alwaysOn: true },
+  { name: "git_checkout", description: "Switch branches.", category: "git", alwaysOn: true },
+  { name: "git_diff", description: "Show diff of working tree.", category: "git", alwaysOn: true },
+  { name: "git_log", description: "Show recent commits.", category: "git", alwaysOn: true },
+  { name: "git_verify_remote_branch", description: "Verify a branch was pushed and is ahead of base.", category: "git", alwaysOn: true },
+  { name: "pr_create", description: "Open a draft PR on GitHub for the pushed branch.", category: "git", alwaysOn: true },
+];
+
+const SUBAGENT_TOOLS: ToolCatalogEntry[] = [
+  // explore subagent surface — read-only
+  { name: "read", description: "Read file contents.", category: "files", alwaysOn: true },
+  { name: "list", description: "List directory entries.", category: "files", alwaysOn: true },
+  { name: "find", description: "Find files by glob.", category: "files", alwaysOn: true },
+  { name: "grep", description: "Search file contents by regex.", category: "files", alwaysOn: true },
+];
+
+export function getOrchestratorToolCatalog(): ToolCatalogEntry[] {
+  return ORCHESTRATOR_TOOLS;
+}
+
+export function getSubagentToolCatalog(): ToolCatalogEntry[] {
+  return SUBAGENT_TOOLS;
+}

--- a/test/skills-tool-catalog-http.test.ts
+++ b/test/skills-tool-catalog-http.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration tests for the new UI surfacing endpoints:
+ *   - GET /api/skills/all  → merged personal + built-in skills
+ *   - GET /api/tool-catalog → static orchestrator + subagent tool catalogs
+ *
+ * These power the "Skills" and "Tools" sidebar panels.
+ */
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import type { Env } from "../src/types";
+
+vi.mock("@cloudflare/codemode", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@cloudflare/codemode")>();
+  return {
+    ...actual,
+    DynamicWorkerExecutor: vi.fn(function () {
+      return { execute: vi.fn().mockResolvedValue({ logs: [], result: null }) };
+    }) as unknown as typeof import("@cloudflare/codemode").DynamicWorkerExecutor,
+  };
+});
+vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/notify", () => ({ dispatchNotification: vi.fn() }));
+
+import worker from "../src/index";
+
+const BASE_URL = "https://dodo.example";
+
+async function fetchJson(path: string, init?: RequestInit): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(new Request(`${BASE_URL}${path}`, init), env as Env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+describe("UI surfacing: /api/skills/all and /api/tool-catalog", () => {
+  beforeAll(async () => {
+    for (let i = 0; i < 3; i++) {
+      const res = await fetchJson("/health");
+      if (res.status === 200) break;
+    }
+  });
+
+  it("GET /api/tool-catalog returns orchestrator + subagent catalogs", async () => {
+    const res = await fetchJson("/api/tool-catalog");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      orchestrator: Array<{ name: string; description: string; category: string }>;
+      subagent: Array<{ name: string }>;
+    };
+    expect(body.orchestrator.length).toBeGreaterThan(10);
+    expect(body.subagent.length).toBeGreaterThan(0);
+    // Built-in tools we depend on
+    const orchestrators = new Set(body.orchestrator.map((t) => t.name));
+    for (const required of ["explore", "task", "read", "write", "edit", "skill"]) {
+      expect(orchestrators.has(required)).toBe(true);
+    }
+  });
+
+  it("GET /api/skills/all merges personal + built-in", async () => {
+    // Create a personal skill so the merged list has at least one of each.
+    await fetchJson("/api/skills", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "test-merged",
+        description: "Used to assert /api/skills/all merges sources",
+        body: "# body",
+      }),
+    });
+
+    const res = await fetchJson("/api/skills/all");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      skills: Array<{ name: string; description: string; source: "personal" | "builtin"; enabled: boolean }>;
+    };
+    expect(body.skills.length).toBeGreaterThan(0);
+    const sources = new Set(body.skills.map((s) => s.source));
+    expect(sources.has("builtin")).toBe(true);
+    // The personal skill we just created must be in the list.
+    expect(body.skills.some((s) => s.name === "test-merged" && s.source === "personal")).toBe(true);
+    // No source we don't expect.
+    for (const s of body.skills) {
+      expect(["personal", "builtin"]).toContain(s.source);
+    }
+  });
+});

--- a/test/tool-catalog-unit.test.ts
+++ b/test/tool-catalog-unit.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for the static tool catalog and the merged skills endpoint.
+ *
+ * These exist mainly to catch drift:
+ *   - tool-catalog should always have at least the core file ops
+ *   - every entry must have a non-empty name and description
+ *   - the system prompt's tool table is the canonical surface; this
+ *     catalog mirrors it for the UI
+ */
+import { describe, expect, it } from "vitest";
+import {
+  getOrchestratorToolCatalog,
+  getSubagentToolCatalog,
+} from "../src/tool-catalog";
+
+describe("tool-catalog", () => {
+  it("returns a non-empty orchestrator catalog with required core tools", () => {
+    const tools = getOrchestratorToolCatalog();
+    expect(tools.length).toBeGreaterThan(10);
+    const names = new Set(tools.map((t) => t.name));
+    for (const required of ["explore", "task", "read", "write", "edit", "grep", "todo_add", "skill", "git_commit"]) {
+      expect(names.has(required), `missing required tool '${required}'`).toBe(true);
+    }
+  });
+
+  it("every entry has a non-empty name, description, and category", () => {
+    for (const t of getOrchestratorToolCatalog()) {
+      expect(t.name).toMatch(/^[a-z_]+$/);
+      expect(t.description.length).toBeGreaterThan(0);
+      expect(t.category).toBeTruthy();
+      expect(typeof t.alwaysOn).toBe("boolean");
+    }
+  });
+
+  it("subagent catalog is read-only", () => {
+    const tools = getSubagentToolCatalog();
+    // explore subagent surface is intentionally read-only — no `write`/`edit`.
+    const names = new Set(tools.map((t) => t.name));
+    expect(names.has("read")).toBe(true);
+    expect(names.has("write")).toBe(false);
+    expect(names.has("edit")).toBe(false);
+  });
+
+  it("does not duplicate tool names", () => {
+    const tools = getOrchestratorToolCatalog();
+    const names = tools.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});


### PR DESCRIPTION
## What

Two new sidebar sections in the Tools tab:

- **Skills** — lists merged personal + built-in skills with source badges
- **Tools** — lists the orchestrator's always-on tool catalog grouped by category

Backed by two new endpoints:

- `GET /api/skills/all` returns personal + built-in skills merged (personal overrides built-in, matches `mergeSkills` precedence)
- `GET /api/tool-catalog` returns static orchestrator + subagent catalogs from `src/tool-catalog.ts`

## Why

A Dodo user asked 'where can I see all configured skills and tools the agent has?' and the answer was 'nowhere in the UI' — the system prompt has a tool table but it's not surfaced to humans. This PR makes it visible.

Workspace skills (`.dodo/skills/` etc. inside the cloned repo) are intentionally excluded from `/api/skills/all` because they're session-scoped — a future PR can add a per-session view if needed.

## How

- New file `src/tool-catalog.ts` is the single source of truth for the UI tool list; mirrors the table in the system prompt
- Registered `/api/skills/all` **before** `/api/skills/:name` so Hono doesn't route 'all' as a skill name
- Test coverage: `test/tool-catalog-unit.test.ts` (catches drift), `test/skills-tool-catalog-http.test.ts` (end-to-end)

## Testing

```
npx vitest run test/tool-catalog-unit.test.ts test/skills-tool-catalog-http.test.ts test/skills-http.test.ts test/skill-registry-unit.test.ts test/skill-tool-binding-unit.test.ts
# all pass (41 tests)
```

## Caveats

- The tool catalog is hand-curated. If a new tool is added in `src/agentic.ts` without updating `src/tool-catalog.ts`, the UI will under-report. A future improvement is auto-discovery, but this static catalog is good enough to ship.

beep-boop-🤖