### PR TITLE
fix(explore): attach recovery hint to failure summaries

### DIFF
--- a/src/agentic.ts
+++ b/src/agentic.ts
@@ -12,6 +12,7 @@ import { getKnownRepo, listKnownRepos, parseRemoteSpec } from "./repos";
 import {
   buildProviderForModel,
   capToolOutputs,
+  EXPLORE_FALLBACK_HINT,
   EXPLORE_MAX_STEPS,
   EXPLORE_SYSTEM_PROMPT,
   EXPLORE_TIMEOUT_MS,
@@ -694,7 +695,11 @@ function buildSubagentTool(spec: {
         ].filter(Boolean).join("\n");
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        return `${spec.name} failed (model: ${modelId}): ${msg}`;
+        const base = `${spec.name} failed (model: ${modelId}): ${msg}`;
+        // Only Explore gets the read-only fallback hint — Task subagent
+        // failures don't have a clean fallback path (they can write, and
+        // the orchestrator can't reliably substitute).
+        return spec.name === "Explore" ? `${base}\n${EXPLORE_FALLBACK_HINT}` : base;
       }
     },
   });
@@ -785,7 +790,7 @@ function buildExploreTool(
             return result.summary;
           } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
-            return `Explore failed (facet mode): ${msg}`;
+            return `Explore failed (facet mode): ${msg}\n${EXPLORE_FALLBACK_HINT}`;
           }
         }
 
@@ -802,12 +807,14 @@ function buildExploreTool(
           `# Parallel explore — ${queries.length} queries in parallel`,
           "",
         ];
+        let allFailed = true;
         for (let i = 0; i < settled.length; i++) {
           const q = queries[i];
           const outcome = settled[i];
           blocks.push(`## Query ${i + 1}: ${q}`, "");
           if (outcome.status === "fulfilled") {
             blocks.push(outcome.value.summary, "");
+            allFailed = false;
           } else {
             const reason = outcome.reason instanceof Error
               ? outcome.reason.message
@@ -815,6 +822,10 @@ function buildExploreTool(
             blocks.push(`(query ${i + 1} failed: ${reason})`, "");
           }
         }
+        // Only attach the global recovery hint if every query failed —
+        // partial success is still useful and the per-query failure
+        // lines stand on their own.
+        if (allFailed) blocks.push(EXPLORE_FALLBACK_HINT);
         return blocks.join("\n").trimEnd();
       },
     });

--- a/src/explore-agent.ts
+++ b/src/explore-agent.ts
@@ -10,6 +10,7 @@ import {
   EXPLORE_SYSTEM_PROMPT,
   EXPLORE_MAX_STEPS,
   EXPLORE_TIMEOUT_MS,
+  EXPLORE_FALLBACK_HINT,
   resolveSubagentModel,
 } from "./subagent-runner";
 import type { AppConfig, Env } from "./types";
@@ -233,7 +234,7 @@ export class ExploreAgent extends Agent<Env> {
       };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      const failureSummary = `Explore failed (model: ${modelId}) [facet: ${this.name}]: ${msg}`;
+      const failureSummary = `Explore failed (model: ${modelId}) [facet: ${this.name}]: ${msg}\n${EXPLORE_FALLBACK_HINT}`;
       this.recordTranscript("assistant", failureSummary, { model: modelId });
       return {
         ok: true,

--- a/src/subagent-runner.ts
+++ b/src/subagent-runner.ts
@@ -378,6 +378,26 @@ export function buildProviderForModel(modelId: string, config: AppConfig, env: E
 export const EXPLORE_MAX_STEPS = 16;
 export const EXPLORE_TIMEOUT_MS = 60_000;
 
+/**
+ * Standard hint appended to every explore failure summary. Tells the
+ * orchestrator that the failure is transient and points it at the
+ * direct read-only tools so it can complete the task without explore.
+ *
+ * Why this exists: we saw three real sessions where explore returned
+ * "internal API error" and the orchestrator (small model, no recovery
+ * heuristic) declared the task impossible and stopped — instead of
+ * just running `list` + `grep` directly. The hint short-circuits that
+ * dead-end.
+ */
+export const EXPLORE_FALLBACK_HINT = [
+  "",
+  "Recovery: explore is unavailable on this call. Continue the task using `list`,",
+  "`find`, `grep`, and `read` directly — they are always available. If the",
+  "workspace appears empty, the repo has not been cloned yet; use `git_clone`",
+  "or `git_clone_known` first. Do NOT report the task as impossible just",
+  "because explore failed.",
+].join("\n");
+
 export const EXPLORE_SYSTEM_PROMPT = [
   "You are a search assistant. Your job is to find files and code relevant to the user's query.",
   "",

--- a/test/explore-failure-fallback-unit.test.ts
+++ b/test/explore-failure-fallback-unit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Failure-path tests for the explore subagent. Asserts that when the
+ * underlying runSubagent call throws, the formatted failure summary
+ * includes EXPLORE_FALLBACK_HINT so the orchestrator doesn't give up.
+ *
+ * The mock's `shouldFail` heuristic throws for prompts containing
+ * "This should fail" / "This will fail".
+ */
+import { describe, expect, it, vi } from "vitest";
+import { env } from "cloudflare:workers";
+import type { Env, AppConfig } from "../src/types";
+import { EXPLORE_FALLBACK_HINT } from "../src/subagent-runner";
+
+vi.mock("@cloudflare/codemode", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@cloudflare/codemode")>();
+  return {
+    ...actual,
+    DynamicWorkerExecutor: vi.fn(function () {
+      return { execute: vi.fn().mockResolvedValue({ logs: [], result: null }) };
+    }) as unknown as typeof import("@cloudflare/codemode").DynamicWorkerExecutor,
+  };
+});
+vi.mock("../src/agentic", async () => await import("./helpers/agentic-mock"));
+vi.mock("../src/subagent-runner", async () => await import("./helpers/subagent-runner-mock"));
+vi.mock("../src/notify", () => ({
+  dispatchNotification: vi.fn(),
+}));
+
+// Override runSubagent to throw — covers the catch block in
+// ExploreAgent.query() which formats the EXPLORE_FALLBACK_HINT into
+// the summary.
+vi.mock("../src/subagent-runner", async () => {
+  const base = await import("./helpers/subagent-runner-mock");
+  return {
+    ...base,
+    runSubagent: vi.fn().mockRejectedValue(new Error("internal API error")),
+  };
+});
+
+function makeParentConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    activeGateway: "opencode",
+    aiGatewayBaseURL: "https://mock-ai-gateway.example/v1",
+    gitAuthorEmail: "dodo@example.com",
+    gitAuthorName: "Dodo",
+    model: "anthropic/claude-sonnet-4",
+    opencodeBaseURL: "https://mock-opencode.example/v1",
+    exploreMode: "facet",
+    taskMode: "inprocess",
+    ...overrides,
+  };
+}
+
+describe("ExploreAgent.query — failure produces a fallback hint", () => {
+  it("appends EXPLORE_FALLBACK_HINT to the summary when runSubagent throws", async () => {
+    const { getAgentByName } = await import("agents");
+    const testEnv = env as Env;
+    const sessionId = `facet-explore-fail-${crypto.randomUUID()}`;
+
+    const parent = await getAgentByName(testEnv.CODING_AGENT as never, sessionId) as unknown as {
+      runExploreFacet: (
+        name: string,
+        opts: { q: string; parentSessionId?: string; parentConfig?: AppConfig },
+      ) => Promise<{ ok: true; facetName: string; summary: string }>;
+    };
+
+    const result = await parent.runExploreFacet("pool-explore-0", {
+      q: "anything triggers failure",
+      parentSessionId: sessionId,
+      parentConfig: makeParentConfig(),
+    });
+
+    // The facet always returns ok:true — errors surface via `summary`.
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain("Explore failed");
+    expect(result.summary).toContain("internal API error");
+    // The recovery hint must be attached so the orchestrator knows to
+    // continue with direct read-only tools instead of giving up.
+    expect(result.summary).toContain(EXPLORE_FALLBACK_HINT);
+    // Sanity check: every fallback tool name appears in the summary.
+    for (const tool of ["list", "find", "grep", "read"]) {
+      expect(result.summary).toContain(`\`${tool}\``);
+    }
+  });
+});

--- a/test/explore-fallback-hint-unit.test.ts
+++ b/test/explore-fallback-hint-unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit tests for EXPLORE_FALLBACK_HINT.
+ *
+ * The hint is the difference between an orchestrator giving up after a
+ * transient explore failure and an orchestrator continuing the task with
+ * direct read-only tools. We assert:
+ *
+ *   1. The constant exists and contains the recovery instruction.
+ *   2. The list of tools the hint points the orchestrator at matches
+ *      what's actually available read-only (no stale tool names).
+ */
+import { describe, expect, it } from "vitest";
+import { EXPLORE_FALLBACK_HINT } from "../src/subagent-runner";
+
+describe("EXPLORE_FALLBACK_HINT", () => {
+  it("is a non-empty string", () => {
+    expect(typeof EXPLORE_FALLBACK_HINT).toBe("string");
+    expect(EXPLORE_FALLBACK_HINT.length).toBeGreaterThan(20);
+  });
+
+  it("names the read-only tools the orchestrator should fall back to", () => {
+    // Every one of these is always-on in the orchestrator catalog —
+    // see src/tool-catalog.ts (once PR #71 lands) and src/agentic.ts.
+    for (const tool of ["list", "find", "grep", "read"]) {
+      expect(EXPLORE_FALLBACK_HINT).toContain(`\`${tool}\``);
+    }
+  });
+
+  it("mentions git_clone for the empty-workspace case", () => {
+    expect(EXPLORE_FALLBACK_HINT).toMatch(/git_clone/);
+  });
+
+  it("instructs the model not to give up", () => {
+    expect(EXPLORE_FALLBACK_HINT).toMatch(/[Dd]o NOT report.*impossible/);
+  });
+});

--- a/test/helpers/subagent-runner-mock.ts
+++ b/test/helpers/subagent-runner-mock.ts
@@ -10,6 +10,18 @@ export const TASK_FACET_TIMEOUT_MS = 600_000;
 export const EXPLORE_SYSTEM_PROMPT = "You are a search assistant (mock).";
 export const TASK_SYSTEM_PROMPT = "You are a focused subagent (mock).";
 
+// Re-export the hint verbatim so failure-path assertions work in tests
+// that mock the runner. Keeping it identical to the real export ensures
+// `expect(summary).toContain(EXPLORE_FALLBACK_HINT)` is a meaningful check.
+export const EXPLORE_FALLBACK_HINT = [
+  "",
+  "Recovery: explore is unavailable on this call. Continue the task using `list`,",
+  "`find`, `grep`, and `read` directly — they are always available. If the",
+  "workspace appears empty, the repo has not been cloned yet; use `git_clone`",
+  "or `git_clone_known` first. Do NOT report the task as impossible just",
+  "because explore failed.",
+].join("\n");
+
 // Pass-through helpers — real behaviour is fine for tests since they
 // touch no I/O.
 export function capToolOutputs<T extends Record<string, unknown>>(tools: T): T {


### PR DESCRIPTION
## What

When the `explore` subagent fails, append a standard `EXPLORE_FALLBACK_HINT` to the failure summary telling the orchestrator to fall back to `list` / `find` / `grep` / `read` directly.

## Why

Three real Dodo sessions in a row got abandoned because:

1. The orchestrator tried `explore` for codebase discovery
2. `explore` returned `internal API error` (transient — AI Gateway hiccup or facet model issue)
3. The orchestrator (a smaller model in these cases) saw the bare error string and declared the whole task impossible
4. The user had to keep prompting 'check your memory' / 'don't stop until you're done' / 'do what you need to do without my input'

The hint short-circuits that dead-end. It's especially valuable for smaller orchestrator models that lack a built-in recovery heuristic.

## How

- New `EXPLORE_FALLBACK_HINT` constant in `src/subagent-runner.ts` — single source of truth
- Appended in three failure paths:
  - `ExploreAgent.query()` catch block (`src/explore-agent.ts`)
  - facet single-query catch (`src/agentic.ts`)
  - facet parallel fan-out (`src/agentic.ts`) — but **only** when every query failed; partial success doesn't need the hint
  - in-process `buildSubagentTool` catch (`src/agentic.ts`), gated on `spec.name === 'Explore'` so Task failures are untouched

Task subagent failures are deliberately not modified — task can write to the workspace, so there is no clean 'fall back to read-only direct tools' substitution.

## Testing

```
npx vitest run test/explore-fallback-hint-unit.test.ts test/explore-failure-fallback-unit.test.ts test/facet-explore-unit.test.ts test/facet-explore-parallel-unit.test.ts test/subagent-model-unit.test.ts test/subagent-prune-unit.test.ts
# all pass (30 tests)
```

## Linked context

- These same three sessions also motivated PR #71 (skills/tools UI surfacing)
- Diagnosis details in https://github.com/jonnyparris/dodo (memory:learnings)

beep-boop-🤖