### PR TITLE
fix(compaction): force/truncated bypass the minMessages guard

### DIFF
--- a/src/compaction-policy.ts
+++ b/src/compaction-policy.ts
@@ -28,13 +28,23 @@ export interface CompactionInputs {
 
 /** Should the session trigger a compaction pass? */
 export function shouldCompact(inputs: CompactionInputs): boolean {
-  const minMessages = inputs.minMessages ?? 6;
+  // Emergency / forced compaction bypasses BOTH the usage check and the
+  // minMessages guard. Without this short-circuit, a first-turn balloon
+  // (e.g. a single assistant turn with many tool calls that compound to
+  // 200k+ input tokens) silently skips compaction because the persisted
+  // messageCount is still 2 (user + assistant) — well below the default
+  // minMessages of 6. The same applies after assembleContext() truncates
+  // history; we need a way to opt back in regardless of message count.
+  //
+  // We still require at least 2 real messages to have something to
+  // summarise — compacting 1 message is a no-op and 0 is a crash.
+  if (inputs.force || inputs.contextWasTruncated) {
+    return inputs.realMessageCount >= 2;
+  }
 
+  const minMessages = inputs.minMessages ?? 6;
   if (inputs.messageCount < minMessages) return false;
   if (inputs.realMessageCount < minMessages) return false;
-
-  // Emergency / forced compaction bypasses the usage check.
-  if (inputs.force || inputs.contextWasTruncated) return true;
 
   const tokenBudget = Math.floor(inputs.modelContextWindow * 0.8);
   if (tokenBudget <= 0) return false;

--- a/test/compaction-policy-unit.test.ts
+++ b/test/compaction-policy-unit.test.ts
@@ -58,6 +58,50 @@ describe("shouldCompact", () => {
     });
     expect(result).toBe(true);
   });
+
+  // Regression: force used to be gated by the minMessages guard, which
+  // meant first-turn balloons (one assistant turn with many tool calls
+  // pushing input tokens past 200k while messageCount stayed at 2) silently
+  // skipped compaction. The force / contextWasTruncated short-circuit must
+  // bypass minMessages entirely. See memory/learnings/dodo-orchestrator-model-matters.md.
+  it("force=true bypasses the minMessages guard (2 messages is enough)", () => {
+    const result = shouldCompact({
+      messageCount: 2,
+      realMessageCount: 2,
+      estimatedTokens: 1,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.5,
+      force: true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("contextWasTruncated=true bypasses the minMessages guard", () => {
+    const result = shouldCompact({
+      messageCount: 3,
+      realMessageCount: 3,
+      estimatedTokens: 100,
+      modelContextWindow: 10_000,
+      thresholdRatio: 0.5,
+      contextWasTruncated: true,
+    });
+    expect(result).toBe(true);
+  });
+
+  // Edge case: force still needs SOMETHING to compact. Single-message
+  // sessions (just the user prompt, no assistant turn yet) have no real
+  // content to summarise.
+  it("force=true with only 1 real message still returns false (nothing to compact)", () => {
+    const result = shouldCompact({
+      messageCount: 1,
+      realMessageCount: 1,
+      estimatedTokens: 50_000,
+      modelContextWindow: 100_000,
+      thresholdRatio: 0.5,
+      force: true,
+    });
+    expect(result).toBe(false);
+  });
 });
 
 describe("pickCutoff", () => {


### PR DESCRIPTION
## What

Move the `force` / `contextWasTruncated` short-circuit **above** the minMessages guard in `shouldCompact()`.

## Why

Autocompaction is wired in three places (loop-entry, mid-loop, pre-step) but it was unreachable on the **first turn** when the model ballooned input tokens — exactly the scenario where compaction matters most.

Reproduced this morning by running 3 prompts on fresh sessions. Each had:
- `messageCount: 2` (user + assistant)
- `totalTokenInput: 199,963 / 199,662 / 213,691`
- `compactionCount: 0`
- Final assistant turn: 'context budget exhausted, please retry in a new session'

Trace through the code:

1. `onChatMessage` runs one streamText iteration
2. The model makes many tool calls in that single turn (clone + explore + read…)
3. Each tool result inflates the message array fed back to streamText, but is **not persisted** as a separate `role:assistant` row — `messageCount` stays at 2
4. `runWatchdogCheck` / wrap-up / pre-step compaction all call `maybeCompactContext({ force: true })`
5. `maybeCompactContext` calls `shouldCompact({ messageCount: 2, force: true, … })`
6. **`shouldCompact` returns false** because `messageCount < 6`, ignoring `force`
7. No compaction happens, the wrap-up injection fires, session ends prematurely

The minMessages guard was added to avoid pointlessly compacting brand-new sessions (compacting one message is a no-op). But `force` and `contextWasTruncated` are emergency signals — the caller has already decided compaction is warranted. They should bypass the guard.

## How

Reordered the two checks. `force` / `contextWasTruncated` now short-circuit immediately, requiring only `realMessageCount >= 2` (you need *something* to compact). Non-emergency compaction still respects the minMessages threshold.

```ts
// Before
if (messageCount < minMessages) return false;  // force never reached
if (force || contextWasTruncated) return true;

// After
if (force || contextWasTruncated) return realMessageCount >= 2;
if (messageCount < minMessages) return false;
```

## Tests

- New: `force=true bypasses the minMessages guard (2 messages is enough)`
- New: `contextWasTruncated=true bypasses the minMessages guard`
- New: `force=true with only 1 real message still returns false (nothing to compact)`
- All 21 existing compaction tests still pass (`compaction-policy-unit`, `compaction-pipeline`, `compaction-e2e`)

## Linked context

- PR #71 — UI surfacing of skills/tools (same investigation)
- PR #72 — explore failure fallback hint (same investigation)
- `memory/learnings/dodo-orchestrator-model-matters.md`

beep-boop-🤖