### PR TITLE
fix(compaction): mid-loop trigger uses force=true; guard slice underflow

### DIFF
--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1056,7 +1056,15 @@ export class CodingAgent extends Think<Env, DodoConfig> {
           if (budgetUsage >= MID_LOOP_COMPACTION_THRESHOLD && !compactionTriggered) {
             compactionTriggered = true;
             try {
-              await self.maybeCompactContext();
+              // force=true so maybeCompactContext() bypasses the
+              // `lastInputTokens === 0` early-return guard. The mid-loop
+              // trigger fires on the FIRST user turn (before any assistant
+              // message is persisted), so lastInputTokens is always 0 here
+              // and the guard would silently no-op without `force`. The
+              // own-loop has already proved compaction is warranted by
+              // measuring cumulativeInputTokens directly — don't make
+              // maybeCompactContext re-decide.
+              await self.maybeCompactContext({ force: true });
               // Refresh messages from storage and re-assemble with compaction summary.
               const thinkSessionId = self.getCurrentSessionId();
               if (thinkSessionId) {
@@ -4992,8 +5000,20 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     }
 
     const messagesToCompact = realMessages.slice(0, compactCount);
+    // Guard against the pathological case where realMessages has fewer
+    // entries than targetCompactCount (e.g. force=true on the very first
+    // turn, when Think hasn't persisted the assistant message yet and
+    // realMessages.length === 1). Without this we'd hit
+    // `messagesToCompact[1].id` → TypeError on undefined.
+    if (messagesToCompact.length < 2) {
+      log("info", "compaction: skipped — fewer than 2 real messages to compact", {
+        sessionId: this.sessionId(),
+        realMessageCount: realMessages.length,
+      });
+      return;
+    }
     const fromMessageId = messagesToCompact[0].id;
-    const toMessageId = messagesToCompact[compactCount - 1].id;
+    const toMessageId = messagesToCompact[messagesToCompact.length - 1].id;
 
     // Check if this range is already compacted
     const existingCompactions = this.sessions.getCompactions(thinkSessionId);


### PR DESCRIPTION
## What

Two small follow-ups uncovered by deploying #73 and watching `wrangler tail` on a real failed session.

### 1. Mid-loop trigger now passes `force: true`

The mid-loop compaction trigger in `onChatMessage()`'s own-loop was the only one of the three triggers (loop-entry, mid-loop, pre-step) **not** passing `{ force: true }` to `maybeCompactContext()`. Because `maybeCompactContext` early-returns when `lastInputTokens === 0` (no persisted assistant message yet) *unless* `force` is set, the mid-loop call was a silent no-op on the very first user turn — exactly the scenario the own-loop budget check was designed for. The `'mid-loop compaction triggered'` log line still fired so the failure was invisible.

### 2. Slice underflow guard in `maybeCompactContext`

`maybeCompactContext` built `messagesToCompact` via `realMessages.slice(0, compactCount)` and then indexed `messagesToCompact[compactCount - 1]`, which throws `TypeError` when `compactCount > realMessages.length` (e.g. `force: true` on a turn with only 1 persisted message). Now guarded with an early return + log line, and the `toId` lookup uses `messagesToCompact.length - 1`.

## Why

Reproduction (Gemma 4 26B on prompt 'Check whether the Dodo auto-nudge feature is working as intended'):

```
own-loop: step complete  step=0  budgetUsage=10%
own-loop: step complete  step=1  budgetUsage=19%
own-loop: step complete  step=2  budgetUsage=29%
own-loop: step complete  step=3  budgetUsage=38%
own-loop: step complete  step=4  budgetUsage=48%
own-loop: step complete  step=5  budgetUsage=58%
own-loop: mid-loop compaction triggered  step=6  cumulative=118659
…end of stream, compactionCount=0, totalTokenInput=197535
```

The log line lied. `maybeCompactContext()` returned without compacting because `lastInputTokens === 0` (first turn, no persisted assistant yet) and `force` wasn't passed.

## Caveat

This does not fully unblock weak orchestrator models on the first turn. By design, compaction needs **>=2 real persisted messages** to have something meaningful to summarise. The deeper issue (single assistant turn ballooning to 200k tokens before any tool result is persisted, because Think persists only after streamText() completes the whole generator) is captured in `memory/learnings/dodo-orchestrator-model-matters.md` as a future investigation.

Even with this fix, expect Gemma 4 26B as orchestrator to keep failing — the underlying issue is the model not the safety nets. PR is still worth landing because the silent-noop is misleading and the slice-underflow is a real crash risk under `force: true`.

## Tests

- All 21 existing compaction tests pass (`compaction-policy-unit`, `compaction-pipeline`, `compaction-e2e`)
- Typecheck clean

## Linked context

- PR #73 (force/truncated bypass minMessages) — landed on main
- PR #72 (explore failure hint) — open
- PR #71 (skills/tools UI surfacing) — open

beep-boop-🤖