### PR TITLE
fix(own-loop): budget thresholds use projected context, not cumulative cost

### DIFF
--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -1003,14 +1003,59 @@ export class CodingAgent extends Think<Env, DodoConfig> {
             }
           }
 
-          // Budget-aware injections
-          const budgetUsage = cumulativeInputTokens / tokenBudget;
-
-          if (budgetUsage >= HARD_STOP_THRESHOLD) {
-            // Hard stop — yield a wrap-up message and break
-            log("warn", "own-loop: hard stop — budget exhausted", {
+          // ─── Cost runaway backstop ───
+          // Per-call context pressure (below) is the primary stop signal,
+          // but a model stuck in a non-doom-loop loop (tools succeeding,
+          // results changing, but no real progress) could still burn
+          // unbounded tokens. Cap absolute cumulative input at 5× the
+          // context budget. For a 200k-context model that's 1M tokens —
+          // generous for real work, low enough to catch obvious runaway.
+          const COST_RUNAWAY_FACTOR = 5;
+          if (cumulativeInputTokens >= tokenBudget * COST_RUNAWAY_FACTOR) {
+            log("warn", "own-loop: cost runaway backstop", {
               sessionId,
               step,
+              cumulativeInputTokens,
+              tokenBudget,
+              factor: COST_RUNAWAY_FACTOR,
+            });
+            yield {
+              type: "text-delta",
+              id: crypto.randomUUID(),
+              delta: `\n\n[Stopped: cumulative input tokens exceeded ${COST_RUNAWAY_FACTOR}× the context budget — likely loop]\n\n`,
+            };
+            exitReason = "budget-limit";
+            break;
+          }
+
+          // ─── Budget-aware injections (context pressure, not cumulative cost) ───
+          //
+          // The thresholds below tell the model when it's running out of
+          // **context window space**, not when it's spent a lot of tokens.
+          // These are different: cumulative input grows by ~system-prompt
+          // size every step regardless of how much real history the model
+          // is carrying, so gating on cumulative tells the model to bail
+          // when its actual context window has plenty of room.
+          //
+          // We estimate the size of the message array we'd send NEXT to
+          // streamText (system prompt + tools are added by the SDK on top;
+          // this only measures the messages-array portion). That's the
+          // signal that matches what the wrap-up text actually says
+          // ("nearly exhausted... do not read new files").
+          //
+          // `cumulativeInputTokens` is kept for telemetry — logged on every
+          // step-complete line — but no longer gates injections. We
+          // discovered the previous coupling by deploying #75 + #76 and
+          // watching Gemma get told to stop at step 8 of a session where
+          // projected context was at 10%. See PR #77.
+          const projectedNextCallTokens = estimateMessagesTokens(messages);
+          const budgetUsage = projectedNextCallTokens / tokenBudget;
+
+          if (budgetUsage >= HARD_STOP_THRESHOLD) {
+            log("warn", "own-loop: hard stop — projected context budget exhausted", {
+              sessionId,
+              step,
+              projectedNextCallTokens,
               cumulativeInputTokens,
               tokenBudget,
               usage: `${Math.round(budgetUsage * 100)}%`,
@@ -1028,6 +1073,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
             log("info", "own-loop: wrap-up injection", {
               sessionId,
               step,
+              projectedNextCallTokens,
               cumulativeInputTokens,
               tokenBudget,
               usage: `${Math.round(budgetUsage * 100)}%`,
@@ -1041,6 +1087,7 @@ export class CodingAgent extends Think<Env, DodoConfig> {
             log("info", "own-loop: budget warning injection", {
               sessionId,
               step,
+              projectedNextCallTokens,
               cumulativeInputTokens,
               tokenBudget,
               usage: `${Math.round(budgetUsage * 100)}%`,


### PR DESCRIPTION
## What

Make the wrap-up / hard-stop / warn thresholds fire on the size of the message array we're about to send to streamText, not on the running sum of input tokens we've spent this turn.

## Why

The two metrics coincide for providers with prompt caching (Anthropic) but diverge sharply for providers without it (Workers AI: Gemma, Kimi). For a typical Gemma session each per-step `inputTokens` is ~20k regardless of how much real history exists — system prompt + tool definitions dominate the per-call cost. By step 8 the cumulative sum is ~158k (77% of the 205k budget) and the wrap-up injection fires telling the model to stop. But the **actual** message array for the next call is also ~20k — the model has ~180k of context window free.

Today's reproduction (commit `41324ab`):

```
step 0  cumulative=19569   budget=10%
step 1  cumulative=39208   budget=19%
step 2  cumulative=58895   budget=29%
step 3  cumulative=78795   budget=38%
step 4  cumulative=98815   budget=48%
step 5  cumulative=118955  budget=58%  ← mid-loop compaction attempted (noop)
step 6  cumulative=138524  budget=68%
step 7  cumulative=158162  budget=77%  ← budget warning injection fires
step 8  cumulative=177894  budget=87%  ← wrap-up injection fires
        Gemma reads 'context budget nearly exhausted' and stops.
```

At step 8 the actual next-call message array was ~20k. Model had ~180k of room.

## How

```ts
// Before
const budgetUsage = cumulativeInputTokens / tokenBudget;

// After
const projectedNextCallTokens = estimateMessagesTokens(messages);
const budgetUsage = projectedNextCallTokens / tokenBudget;
```

`cumulativeInputTokens` is kept for telemetry — still logged on every step-complete and on the threshold injections — but no longer gates them.

## Cost runaway backstop

Without cumulative-based gating, a model in a non-doom-loop loop could burn unbounded tokens. New absolute backstop: `cumulativeInputTokens >= tokenBudget * 5` (e.g. 1M tokens for a 200k model) exits with `exitReason: budget-limit` and a 'cost runaway' message. Generous for real multi-step work, tight enough to catch billing bombs.

## What this unblocks

Gemma sessions that previously stopped at step 8 with 'context exhausted' should now keep iterating until either:
- the model decides it's done
- per-call projected context actually fills up
- the cost runaway backstop fires

Strong models with prompt caching won't notice (cumulative ≈ projected for them). Weak models with no caching get the full benefit.

## Tests

All 28 existing compaction + prune tests pass. Typecheck clean.

The budget threshold logic isn't directly unit-tested (it lives inside `onChatMessage`'s generator). Behavioural validation via post-deploy Gemma re-run on the failing prompts.

## Linked

- PR #73, #74, #75, #76 (compaction + prune harness chain)
- `memory/learnings/dodo-orchestrator-model-matters.md`

beep-boop-🤖