### PR TITLE
chore(oauth): add oauth4webapi and wiring points

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "cron-schedule": "^6.0.0",
         "hono": "^4.12.9",
         "jose": "^6.1.3",
+        "oauth4webapi": "^3.8.6",
         "typescript": "^5.8.3",
         "zod": "^4.1.11"
       },
@@ -5139,6 +5140,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "cron-schedule": "^6.0.0",
     "hono": "^4.12.9",
     "jose": "^6.1.3",
+    "oauth4webapi": "^3.8.6",
     "typescript": "^5.8.3",
     "zod": "^4.1.11"
   },


### PR DESCRIPTION
**Phase 0 of 7** — cf-portal MCP OAuth support.

Pure dependency addition. No functional changes.

`oauth4webapi` will be used in subsequent phases for:
- PKCE S256 authorization code flow
- Dynamic Client Registration (RFC 7591)
- Token refresh with single-use refresh token handling
- Spec-compliant token introspection

## Verification

- `npm run typecheck` passes
- Diff is two lines: `package.json` + `package-lock.json`
- No `src/` changes

## Plan

Full architecture and 7-phase rollout: `memory/workload/plans/2026-05-26-dodo-cf-portal-oauth.md` (agent-memory).

Next: Phase 1 — per-user OAuth engine in `UserControl` DO with in-DO mutex to prevent Kenny Johnson's documented `invalid_grant` re-auth loop.

beep-boop-🤖