### PR TITLE
fix(mcp): seed new catalog entries on every onStart + integrations-first UI layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -911,16 +911,6 @@
           </details>
         </div>
         <div class="section">
-          <h2>Skills</h2>
-          <p style="font-size:11px;color:var(--muted);margin-bottom:6px">Skills are SKILL.md files the agent loads on demand. Built-in skills ship with Dodo; personal skills you author here. Workspace skills (per-session, from <code>.dodo/skills/</code> etc.) are not shown here.</p>
-          <div id="skills-list"></div>
-        </div>
-        <div class="section">
-          <h2>Tools</h2>
-          <p style="font-size:11px;color:var(--muted);margin-bottom:6px">Tools available to the agent. Dimmed entries are gated on session config (codemode, browser) or reachable only inside a codemode block (most git ops). Configure MCP integrations below to add more.</p>
-          <div id="tool-catalog-list"></div>
-        </div>
-        <div class="section">
           <h2>Integrations</h2>
           <div id="integrations-list"></div>
           <details style="margin-top:6px">
@@ -932,6 +922,20 @@
             <label for="integ-auth-header" class="visually-hidden">Auth header value, optional</label>
             <input id="integ-auth-header" placeholder="Auth header value (optional)" style="margin-bottom:4px"/>
             <button onclick="addIntegration()">Add</button>
+          </details>
+        </div>
+        <div class="section">
+          <details>
+            <summary><h2 style="display:inline;margin:0">Skills</h2></summary>
+            <p style="font-size:11px;color:var(--muted);margin-bottom:6px">Skills are SKILL.md files the agent loads on demand. Built-in skills ship with Dodo; personal skills you author here. Workspace skills (per-session, from <code>.dodo/skills/</code> etc.) are not shown here.</p>
+            <div id="skills-list"></div>
+          </details>
+        </div>
+        <div class="section">
+          <details>
+            <summary><h2 style="display:inline;margin:0">Tools</h2></summary>
+            <p style="font-size:11px;color:var(--muted);margin-bottom:6px">Tools available to the agent. Dimmed entries are gated on session config (codemode, browser) or reachable only inside a codemode block (most git ops). Configure MCP integrations above to add more.</p>
+            <div id="tool-catalog-list"></div>
           </details>
         </div>
         <div class="section">

--- a/src/user-control.ts
+++ b/src/user-control.ts
@@ -1468,25 +1468,29 @@ export class UserControl extends DurableObject<Env> {
       this.ctx.storage.sql.exec("INSERT OR IGNORE INTO user_config (key, value, updated_at) VALUES (?, ?, ?)", key, String(value), now);
     }
 
-    const existingCount = (Array.from(this.ctx.storage.sql.exec("SELECT COUNT(*) AS n FROM approved_mcps WHERE is_deleted = 0"))[0] as SqlRow | null);
-    if (Number(existingCount?.n ?? 0) === 0) {
-      const { getDeployMcpCatalog } = await import("./mcp-catalog");
-      const seedNow = Date.now();
-      for (const entry of getDeployMcpCatalog(this.env)) {
-        this.ctx.storage.sql.exec(
-          `INSERT INTO approved_mcps (mcp_url, id, display_name, description, setup_guide, known_hosts, auth_type, status, is_deleted, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'enabled', 0, ?, ?)`,
-          entry.url,
-          entry.id,
-          entry.name,
-          entry.description ?? null,
-          entry.setupGuide ?? null,
-          JSON.stringify(entry.knownHosts ?? []),
-          entry.auth_type ?? "static_headers",
-          seedNow,
-          seedNow,
-        );
-      }
+    // Seed `approved_mcps` from the code-level catalog. We use `INSERT OR IGNORE`
+    // keyed by `mcp_url` so:
+    //   - On first run, every catalog entry is inserted.
+    //   - On subsequent runs, only NEW entries (not yet in the table) are
+    //     inserted; admin-edited rows and soft-deleted rows are preserved.
+    // This is how adding a new entry to `mcp-catalog.ts` propagates to all
+    // existing UserControl DOs without an explicit migration.
+    const { getDeployMcpCatalog } = await import("./mcp-catalog");
+    const seedNow = Date.now();
+    for (const entry of getDeployMcpCatalog(this.env)) {
+      this.ctx.storage.sql.exec(
+        `INSERT OR IGNORE INTO approved_mcps (mcp_url, id, display_name, description, setup_guide, known_hosts, auth_type, status, is_deleted, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'enabled', 0, ?, ?)`,
+        entry.url,
+        entry.id,
+        entry.name,
+        entry.description ?? null,
+        entry.setupGuide ?? null,
+        JSON.stringify(entry.knownHosts ?? []),
+        entry.auth_type ?? "static_headers",
+        seedNow,
+        seedNow,
+      );
     }
   }
 


### PR DESCRIPTION
Two follow-ups to #83 — the cf-portal entry wasn't showing up in the UI.

## 1. Catalog seed was first-run-only

`/api/mcp-catalog` reads from UserControl's `approved_mcps` SQLite table. The seed code only ran when the table was empty, so existing DOs (seeded before cf-portal was added to the catalog) never picked up the new entry.

**Fix:** Use `INSERT OR IGNORE` on every `onStart`, keyed by `mcp_url` (PRIMARY KEY). New catalog entries flow through; admin-edited / soft-deleted rows are preserved.

Verified live: the deployed catalog endpoint returned only 3 entries (browser-rendering, dodo-self, github) — cf-portal was missing despite being merged in #83. With this fix, the next request triggers an onStart pass that inserts cf-portal.

## 2. Integrations buried below Skills + Tools

Settings panel order was: Skills (~50 entries) → Tools (~30 entries) → Integrations. You couldn't see the OAuth catalog without scrolling past everything.

**Fix:** Move Integrations to the top of that section. Skills and Tools are now wrapped in collapsed `<details>` so they don't dominate the scroll either.

## Verification

- `npm run typecheck` clean
- `npx vitest run` 817/817 pass
- Seed behaviour exercised implicitly by every test that hits the catalog endpoint
- Markup-only change for the layout, no JS touched

## Bonus context: CF Access bypass

Earlier you asked about the bypass. I checked — **no bypass needed**. The OAuth callback (`/agents/oauth/callback`) is on the same origin as Dodo, so the popup inherits the user's `CF_AppSession` cookie when it returns from the OAuth provider. Verified with chrome-devtools by fetching the callback path from an authenticated tab — got 404 (route works, no OAuth code) instead of 302 to Access login. The existing `Dodo MCP (Bypass)` Access app at `dodo.jonnyparris.workers.dev/mcp` already proves the cookie-inheritance model; we don't need an analogous bypass for the OAuth callback path because the callback IS authenticated via the user's already-valid cookie.

beep-boop-🤖
