### PR TITLE
fix(mcp): use getAgentByName for /api/mcp/* OAuth routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1548,11 +1548,12 @@ app.get("/mcp-oauth-error", (c) => {
 </html>`, 400);
 });
 
-// OAuth callback route for MCP server auth flows
+// OAuth callback route for MCP server auth flows.
+// Uses getAgentByName so the hub DO's `.name` is set via setName before the
+// Agents SDK's OAuth callback handler reads it (workerd#2240).
 app.all("/agents/*", async (c) => {
   const userEmail = c.get("userEmail");
-  const id = c.env.CODING_AGENT.idFromName(userEmail);
-  const stub = c.env.CODING_AGENT.get(id);
+  const stub = await getAgentByName(c.env.CODING_AGENT as never, userEmail);
   const h = new Headers(c.req.raw.headers);
   h.set("x-owner-email", userEmail);
   const req = new Request(c.req.raw, { headers: h });
@@ -1590,8 +1591,11 @@ app.post("/api/mcp/start-auth", async (c) => {
   }
 
   const userEmail = c.get("userEmail");
-  const id = c.env.CODING_AGENT.idFromName(userEmail);
-  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+  // Use getAgentByName so the DO's `.name` is set via setName before any
+  // RPC method runs. `idFromName` + `.get()` skips that bookkeeping, which
+  // makes `this.name` throw inside the Agents SDK (workerd#2240) — and the
+  // SDK's `addMcpServer` reads `this.name` to build the OAuth state.
+  const stub = (await getAgentByName(c.env.CODING_AGENT as never, userEmail)) as unknown as {
     addMcpServer: (name: string, url: string, opts: { callbackHost: string; callbackPath: string }) => Promise<{ state: string; authUrl?: string; id: string }>;
   };
 
@@ -1637,8 +1641,8 @@ app.post("/api/mcp/delete-auth", async (c) => {
   }
 
   const userEmail = c.get("userEmail");
-  const id = c.env.CODING_AGENT.idFromName(userEmail);
-  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+  // See /api/mcp/start-auth above for why getAgentByName instead of idFromName.
+  const stub = (await getAgentByName(c.env.CODING_AGENT as never, userEmail)) as unknown as {
     getMcpServers: () => { servers: Record<string, unknown> };
     removeMcpServer: (id: string) => Promise<void>;
   };
@@ -1674,8 +1678,8 @@ app.post("/api/mcp/refresh-state", async (c) => {
   }
 
   const userEmail = c.get("userEmail");
-  const id = c.env.CODING_AGENT.idFromName(userEmail);
-  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+  // See /api/mcp/start-auth above for why getAgentByName instead of idFromName.
+  const stub = (await getAgentByName(c.env.CODING_AGENT as never, userEmail)) as unknown as {
     getMcpServers: () => { servers: Record<string, unknown> };
     refreshMcpState: (id: string) => Promise<void>;
   };
@@ -1701,8 +1705,8 @@ app.post("/api/mcp/refresh-state", async (c) => {
 // source of truth across all of their sessions.
 app.get("/api/mcp/oauth-servers", async (c) => {
   const userEmail = c.get("userEmail");
-  const id = c.env.CODING_AGENT.idFromName(userEmail);
-  const stub = c.env.CODING_AGENT.get(id) as unknown as {
+  // See /api/mcp/start-auth above for why getAgentByName instead of idFromName.
+  const stub = (await getAgentByName(c.env.CODING_AGENT as never, userEmail)) as unknown as {
     getMcpServers: () => Promise<{
       servers: Record<string, {
         name?: string;

--- a/test/dodo.test.ts
+++ b/test/dodo.test.ts
@@ -148,20 +148,24 @@ describe("Dodo foundation", () => {
     expect(messages.messages[1].role).toBe("assistant");
   });
 
-  it("POST /api/mcp/start-auth is not publicly accessible", async () => {
+  it("POST /api/mcp/start-auth requires authentication", async () => {
+    // ALLOW_UNAUTHENTICATED_DEV is what `isDevMode` checks — DEV_MODE alone
+    // does nothing. Clearing ALLOW_UNAUTHENTICATED_DEV forces verifyAccess()
+    // through the production code path, which fails with 500 when CF Access
+    // env vars are also unset.
     const ctx = createExecutionContext();
     const response = await worker.fetch(new Request(`${BASE_URL}/api/mcp/start-auth`, {
       body: JSON.stringify({ mcpUrl: "https://browser.mcp.cloudflare.com/mcp" }),
       headers: { "content-type": "application/json" },
       method: "POST",
-    }), { ...(env as Env), DEV_MODE: "false" } as Env, ctx);
+    }), { ...(env as Env), ALLOW_UNAUTHENTICATED_DEV: "" } as Env, ctx);
     await waitOnExecutionContext(ctx);
     expect(response.status).not.toBe(200);
   });
 
-  it("/agents/* is not publicly accessible", async () => {
+  it("/agents/* requires authentication", async () => {
     const ctx = createExecutionContext();
-    const response = await worker.fetch(new Request(`${BASE_URL}/agents/test`, { method: "GET" }), { ...(env as Env), DEV_MODE: "false" } as Env, ctx);
+    const response = await worker.fetch(new Request(`${BASE_URL}/agents/test`, { method: "GET" }), { ...(env as Env), ALLOW_UNAUTHENTICATED_DEV: "" } as Env, ctx);
     await waitOnExecutionContext(ctx);
     expect(response.status).not.toBe(200);
   });


### PR DESCRIPTION
## Bug

Live debugging via chrome-devtools surfaced this when I clicked "Connect Cloudflare Portal with OAuth":

```
POST /api/mcp/start-auth → 502
{"error":"Failed to start OAuth flow: Attempting to read .name on CodingAgent before it was set..."}
```

This is [workerd#2240](https://github.com/cloudflare/workerd/issues/2240). The Agents SDK's `addMcpServer` reads `this.name` to scope the OAuth state key, but `this.name` is only set when the stub is obtained via `getAgentByName` (which calls `setName` under the hood). Bare `idFromName + .get` skips that.

## Fix

Switch all five OAuth-touching call sites to `getAgentByName`:
- `/api/mcp/start-auth`
- `/api/mcp/delete-auth`
- `/api/mcp/refresh-state`
- `/api/mcp/oauth-servers`
- `/agents/*` (OAuth callback)

Existing non-OAuth code paths (`proxyToAgent` for sessions) already use `getAgentByName` correctly — that's why static-header MCPs and per-session DOs worked fine while the per-user hub's OAuth path didn't.

## Also fix

Two pre-existing tests asserted "not publicly accessible" by passing `DEV_MODE: "false"` — the real flag is `ALLOW_UNAUTHENTICATED_DEV`. Those tests passed for the wrong reason (the prior 502 from the .name bug). Now they assert against the actual auth path.

## Verification

- `npm run typecheck` clean
- `npx vitest run` 817/817 (no regressions; 2 tests had their assumed-auth-failure mechanism corrected)
- Will verify end-to-end via chrome-devtools after deploy

beep-boop-🤖
