### PR TITLE
fix(mcp): OAuth redirect_uri must be /agents/oauth/callback + cleanup stale registrations

### DIFF
--- a/src/coding-agent.ts
+++ b/src/coding-agent.ts
@@ -6327,9 +6327,12 @@ export class CodingAgent extends Think<Env, DodoConfig> {
     const url = server.server_url;
     const name = server.name ?? new URL(url).host;
     await this.removeMcpServer(mcpId);
+    // Mirror the /api/mcp/start-auth callback path. `/agents` (no trailing
+    // segment) doesn't match `app.all("/agents/*")` and returns 404 when
+    // the OAuth provider redirects there.
     await this.addMcpServer(name, url, {
       callbackHost: this.env.WORKER_URL,
-      callbackPath: "/agents",
+      callbackPath: "/agents/oauth/callback",
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1597,11 +1597,33 @@ app.post("/api/mcp/start-auth", async (c) => {
   // SDK's `addMcpServer` reads `this.name` to build the OAuth state.
   const stub = (await getAgentByName(c.env.CODING_AGENT as never, userEmail)) as unknown as {
     addMcpServer: (name: string, url: string, opts: { callbackHost: string; callbackPath: string }) => Promise<{ state: string; authUrl?: string; id: string }>;
+    getMcpServers: () => Promise<{ servers: Record<string, { server_url?: string; state?: string }> }>;
+    removeMcpServer: (id: string) => Promise<void>;
   };
 
   const displayName = parsedUrl.host;
 
   try {
+    // If a previous OAuth attempt for this MCP URL is still in storage,
+    // remove it before starting a new dance. Otherwise the SDK reuses the
+    // stale DCR registration (including the redirect_uri it was created
+    // with), which fails if we've since changed the callback path. The
+    // mismatch surfaces as "Redirect URI not allowed by application
+    // configuration" from the OAuth provider.
+    try {
+      const { servers } = await stub.getMcpServers();
+      for (const [sid, s] of Object.entries(servers)) {
+        if (s.server_url === mcpUrl) {
+          log("info", "start-auth: removing stale MCP server before re-auth", { userEmail, mcpUrl, mcpId: sid, prevState: s.state });
+          await stub.removeMcpServer(sid);
+        }
+      }
+    } catch (cleanupErr) {
+      // Cleanup failures shouldn't block a fresh DCR — the SDK will return
+      // a friendly error if the dance can't proceed.
+      log("warn", "start-auth: pre-auth cleanup failed", { userEmail, mcpUrl, error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) });
+    }
+
     // Derive the callback host from the live request URL, falling back to
     // the env override if the worker is behind a known internal hostname.
     // The previous hard-coded WORKER_URL ("http://localhost:8787") would
@@ -1612,9 +1634,14 @@ app.post("/api/mcp/start-auth", async (c) => {
     const callbackHost = c.env.WORKER_URL && c.env.WORKER_URL !== "http://localhost:8787"
       ? c.env.WORKER_URL
       : inferredHost;
+    // callbackPath must point at a real route, not just the prefix. We
+    // mount `app.all("/agents/*")` (one path segment minimum). Registering
+    // `/agents` as the redirect_uri makes the OAuth provider redirect to a
+    // path that doesn't match the wildcard, and Dodo returns 404. Use a
+    // dedicated, stable subpath under `/agents/`.
     const result = await stub.addMcpServer(displayName, mcpUrl, {
       callbackHost,
-      callbackPath: "/agents",
+      callbackPath: "/agents/oauth/callback",
     });
     if (result.state === "authenticating") {
       return c.json({ authUrl: result.authUrl });


### PR DESCRIPTION
Live-debugged via chrome-devtools. Two related bugs:

## 1. Redirect URI didn't match the route

`addMcpServer` was called with `callbackPath: "/agents"`. The Agents SDK registers that verbatim as the OAuth `redirect_uri` via DCR. But Dodo mounts `app.all("/agents/*")`, which requires at least one segment after `/agents/` — bare `/agents` returns 404. cf-portal also rejected the registration with **"Redirect URI not allowed by application configuration"**.

**Fix:** use `callbackPath: "/agents/oauth/callback"` so the path matches the route handler AND looks like a normal OAuth callback URI to providers.

## 2. Stale DCR registration is reused across attempts

The SDK stores `client_id` + `redirect_uri` per MCP server in hub-DO storage. Once added, subsequent `addMcpServer` calls reuse the registration — including the stale redirect_uri. So just changing `callbackPath` doesn't help users who already failed once.

**Fix:** in `/api/mcp/start-auth`, look up any existing server with the same `server_url` and call `removeMcpServer` first. The SDK's `removeServer` wipes storage (per its docstring), so the next `addMcpServer` does a fresh DCR with the correct redirect URI.

## Verification

- `npm run typecheck` clean
- `npx vitest run` 817/817 pass
- Will verify end-to-end via chrome-devtools after deploy

beep-boop-🤖
