### PR TITLE
fix(mcp): remove cf-portal catalog entry — loopback-only redirect URI policy

### DIFF
--- a/src/mcp-catalog.ts
+++ b/src/mcp-catalog.ts
@@ -50,19 +50,19 @@ const DEFAULT_CLOUDFLARE_REMOTE_MCP_CATALOG: McpCatalogEntry[] = [
     auth_type: "oauth",
     knownHosts: ["browser.mcp.cloudflare.com"],
   },
-  {
-    id: "cf-portal",
-    name: "Cloudflare Portal",
-    description:
-      "Cloudflare internal MCP portal — Backstage catalog, Jira, GitLab, Sentry, Elasticsearch, Wiki, Prometheus, and more. Requires Cloudflare SSO.",
-    url: "https://portal.mcp.cfdata.org/mcp",
-    setupGuide:
-      "Connect with OAuth via Cloudflare Access SSO. Per-user Dynamic Client Registration; access token refreshes automatically.",
-    auth_type: "oauth",
-    // cf-mcp.cloudflareaccess.com is the OAuth dance host
-    // (authorization_endpoint / token_endpoint / registration_endpoint).
-    knownHosts: ["portal.mcp.cfdata.org", "cf-mcp.cloudflareaccess.com"],
-  },
+  // NOTE: cf-portal (https://portal.mcp.cfdata.org/mcp) was tested and is
+  // intentionally NOT in this catalog. Its OAuth authorize endpoint
+  // (cf-mcp.cloudflareaccess.com) only accepts redirect URIs pointing at
+  // loopback (http://127.0.0.1:*) or Cloudflare-managed domains (e.g.
+  // seal-nightly.cloudflare.dev). DCR succeeds, but the authorize step
+  // returns "Redirect URI not allowed by application configuration"
+  // for any other host. This is by design — cf-portal treats third-party
+  // hosted apps as untrusted clients. OpenCode/Cursor/Claude Desktop work
+  // because they run locally on 127.0.0.1; Dodo runs on a Worker, which
+  // can't bind 127.0.0.1 from the user's POV. See OpenCode's
+  // `McpOAuthProvider.redirectUrl` for reference. To use cf-portal tools
+  // in Dodo, run a local mcp-remote proxy and add it as a static-headers
+  // integration.
 ];
 
 export const DEPLOY_MCP_CATALOG_CONFIG: McpCatalogConfig = {

--- a/test/mcp-catalog-unit.test.ts
+++ b/test/mcp-catalog-unit.test.ts
@@ -8,16 +8,12 @@ import { describe, expect, it } from "vitest";
 import { MCP_CATALOG } from "../src/mcp-catalog";
 
 describe("MCP_CATALOG", () => {
-  it("includes cf-portal as an OAuth catalog entry", () => {
+  it("does NOT include cf-portal — its OAuth authorize endpoint rejects non-loopback redirect URIs", () => {
+    // Documented in mcp-catalog.ts. cf-portal works for OpenCode/Cursor/etc
+    // because those clients use http://127.0.0.1:PORT/... redirect URIs.
+    // A hosted Worker can't do that, and cf-portal rejects everything else.
     const entry = MCP_CATALOG.find((e) => e.id === "cf-portal");
-    expect(entry).toBeDefined();
-    expect(entry?.url).toBe("https://portal.mcp.cfdata.org/mcp");
-    expect(entry?.auth_type).toBe("oauth");
-    // Both the MCP host AND the Cloudflare Access OAuth dance host must be
-    // in knownHosts — otherwise `isHostAllowed()` rejects the start-auth
-    // call and the token endpoint round-trip during the dance.
-    expect(entry?.knownHosts).toContain("portal.mcp.cfdata.org");
-    expect(entry?.knownHosts).toContain("cf-mcp.cloudflareaccess.com");
+    expect(entry).toBeUndefined();
   });
 
   it("includes browser-rendering as an OAuth catalog entry", () => {


### PR DESCRIPTION
## What I learned

After 6 PRs of trying to make Dodo connect to cf-portal via OAuth, and finally cross-referencing OpenCode's source (`packages/opencode/src/mcp/oauth-provider.ts`):

```ts
get redirectUrl(): string {
  if (this.config.redirectUri) return this.config.redirectUri
  const port = this.config.callbackPort ?? OAUTH_CALLBACK_PORT  // 19876
  return `http://127.0.0.1:${port}${OAUTH_CALLBACK_PATH}`        // /mcp/oauth/callback
}
```

OpenCode (and Cursor, Claude Desktop, etc) work with cf-portal **because they're local clients using loopback redirect URIs**. They spin up an HTTP server on 127.0.0.1:19876 to catch the callback.

cf-portal's authorize endpoint (`cf-mcp.cloudflareaccess.com`) enforces an allowlist:
- ✅ `http://127.0.0.1:*/...` — accepted (loopback)
- ✅ Cloudflare-managed domains (e.g. `seal-nightly.cloudflare.dev`) — accepted (allowlisted)
- ❌ Everything else — rejected with `Redirect URI not allowed by application configuration`

This is sensible OAuth security: treat third-party hosted apps as untrusted clients, only allow callbacks to locally-controlled URIs or known Cloudflare property.

## What this means for Dodo

A hosted Worker can't bind `127.0.0.1` from the user's perspective. cf-portal as an OAuth target from Dodo is **infeasible by design**, not by bug.

## Fix

Remove the cf-portal catalog entry. The comment in `mcp-catalog.ts` documents the reasoning. Test updated to assert the entry's absence.

## Workaround for cf-portal access in Dodo (out of scope)

Run a local `mcp-remote` proxy on the user's machine that does the loopback OAuth, then expose it to Dodo as a static-headers MCP integration. Defeats the point of Dodo being hosted, but it's how Cursor users do it. Not implementing this here.

## What stays in place

All the supporting infrastructure from PRs #82–#88 remains useful for any future OAuth-MCP entry that allows remote redirect URIs:
- OAuth start-auth / delete-auth / refresh-state endpoints
- Popup + polling UX
- Stale-registration cleanup before retry
- `getAgentByName` fix (workerd#2240)
- Integrations panel moved above Skills/Tools

The browser-rendering and github OAuth entries are still in the catalog. github has its own issue (`Incompatible auth server: does not support dynamic client registration` — needs a pre-registered client_id which we don't expose yet). browser-rendering has a separate dedicated UI section that wasn't testable in this scope.

## Verification

- `npm run typecheck` clean
- `npx vitest run` 817/817 pass
- The integrations panel no longer shows cf-portal once redeployed

beep-boop-🤖
